### PR TITLE
Create skeleton application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,17 @@ env:
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
+        - PYTEST_VERSION=3.1
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         - EVENT_TYPE='pull_request push'
 
-        
+
         # List other runtime dependencies for the package that are available as
         # conda packages here.
         - CONDA_DEPENDENCIES=''
-        
+
         # List other runtime dependencies for the package that are available as
         # pip packages here.
         # - PIP_DEPENDENCIES=''

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -7,6 +7,3 @@ from glue.app.qt.application import GlueApplication
 def main():
     app = GlueApplication()
     sys.exit(app.start())
-
-if __name__ == '__main__':
-    main()

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -4,6 +4,9 @@ import sys
 from glue.app.qt.application import GlueApplication
 
 
+def setup():
+    pass
+
 def main():
     app = GlueApplication()
     sys.exit(app.start())

--- a/cubeviz/main.py
+++ b/cubeviz/main.py
@@ -1,0 +1,12 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
+
+from glue.app.qt.application import GlueApplication
+
+
+def main():
+    app = GlueApplication()
+    sys.exit(app.start())
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,10 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'gui_scripts': ['cubeviz=cubeviz.cubeviz:main']}
+entry_points = {
+    'gui_scripts': ['cubeviz=cubeviz.cubeviz:main'],
+    'glue.plugins': ['cubeviz=cubeviz.cubeviz:setup']
+}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'console_scripts': []}
+entry_points = {'console_scripts': ['cubeviz=cubeviz.main:main']}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'console_scripts': ['cubeviz=cubeviz.cubeviz:main']}
+entry_points = {'gui_scripts': ['cubeviz=cubeviz.cubeviz:main']}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'console_scripts': ['cubeviz=cubeviz.main:main']}
+entry_points = {'console_scripts': ['cubeviz=cubeviz.cubeviz:main']}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')


### PR DESCRIPTION
This is extremely basic (but hopefully moving in the right direction). It's worth mentioning that I believe that if we're testing against stable versions of `astropy` we're going to need to restrict the `pytest` version to v3.1 or earlier, which is the reason for the change to the travis config.