### PR TITLE
Added initial draft of custom CubeViz layout

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -1,0 +1,68 @@
+from __future__ import print_function, division
+
+from glue.config import qt_fixed_layout_tab
+from qtpy.QtWidgets import QSplitter, QWidget, QVBoxLayout, QHBoxLayout
+from qtpy.QtCore import Qt, QEvent, Signal
+from glue.viewers.image.qt import ImageViewer
+from specviz.external.glue.data_viewer import SpecVizViewer
+
+
+class WidgetWrapper(QWidget):
+
+    def __init__(self, widget=None, tab_widget=None, parent=None):
+        super(WidgetWrapper, self).__init__(parent=parent)
+        self.tab_widget = tab_widget
+        self._widget = widget
+        self.layout = QVBoxLayout()
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.layout.addWidget(widget)
+        self.setLayout(self.layout)
+        for child in self.children():
+            if child.isWidgetType():
+                child.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.MouseButtonPress:
+            self.tab_widget.subWindowActivated.emit(self)
+        return super(WidgetWrapper, self).eventFilter(obj, event)
+
+    def widget(self):
+        return self._widget
+
+
+@qt_fixed_layout_tab
+class CubeVizLayout(QSplitter):
+    """
+    The 'CubeViz' layout, with three image viewers and one spectrum viewer.
+    """
+
+    LABEL = "CubeViz"
+    subWindowActivated = Signal(object)
+
+    def __init__(self, session=None, parent=None):
+        super(CubeVizLayout, self).__init__(parent=parent)
+        self.session = session
+        self.setOrientation(Qt.Vertical)
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.image1 = WidgetWrapper(ImageViewer(self.session), tab_widget=self)
+        self.image2 = WidgetWrapper(ImageViewer(self.session), tab_widget=self)
+        self.image3 = WidgetWrapper(ImageViewer(self.session), tab_widget=self)
+        self.specviz = WidgetWrapper(SpecVizViewer(self.session), tab_widget=self)
+        layout.addWidget(self.image1)
+        layout.addWidget(self.image2)
+        layout.addWidget(self.image3)
+        widget = QWidget()
+        widget.setLayout(layout)
+        self.addWidget(widget)
+        self.addWidget(self.specviz)
+        self.subWindowActivated.connect(self._update_active_widget)
+
+    def _update_active_widget(self, widget):
+        self._active_widget = widget
+
+    def activeSubWindow(self):
+        return self._active_widget
+
+    def subWindowList(self):
+        return [self.image1, self.image2, self.image3, self.specviz]

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -1,19 +1,22 @@
 from __future__ import print_function, division
 
-from glue.config import qt_fixed_layout_tab
-from qtpy.QtWidgets import QSplitter, QWidget, QVBoxLayout, QHBoxLayout
-from qtpy.QtCore import Qt, QEvent, Signal
+import os
+
+from glue.config import qt_fixed_layout_tab, startup_action
+from qtpy import QtWidgets, QtCore
 from glue.viewers.image.qt import ImageViewer
 from specviz.external.glue.data_viewer import SpecVizViewer
+from glue.utils.qt import load_ui
+from glue.external.echo import keep_in_sync
 
 
-class WidgetWrapper(QWidget):
+class WidgetWrapper(QtWidgets.QWidget):
 
     def __init__(self, widget=None, tab_widget=None, parent=None):
         super(WidgetWrapper, self).__init__(parent=parent)
         self.tab_widget = tab_widget
         self._widget = widget
-        self.layout = QVBoxLayout()
+        self.layout = QtWidgets.QVBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layout.addWidget(widget)
         self.setLayout(self.layout)
@@ -22,7 +25,7 @@ class WidgetWrapper(QWidget):
                 child.installEventFilter(self)
 
     def eventFilter(self, obj, event):
-        if event.type() == QEvent.MouseButtonPress:
+        if event.type() == QtCore.QEvent.MouseButtonPress:
             self.tab_widget.subWindowActivated.emit(self)
         return super(WidgetWrapper, self).eventFilter(obj, event)
 
@@ -31,32 +34,54 @@ class WidgetWrapper(QWidget):
 
 
 @qt_fixed_layout_tab
-class CubeVizLayout(QSplitter):
+class CubeVizLayout(QtWidgets.QWidget):
     """
     The 'CubeViz' layout, with three image viewers and one spectrum viewer.
     """
 
     LABEL = "CubeViz"
-    subWindowActivated = Signal(object)
+    subWindowActivated = QtCore.Signal(object)
 
     def __init__(self, session=None, parent=None):
         super(CubeVizLayout, self).__init__(parent=parent)
+
         self.session = session
-        self.setOrientation(Qt.Vertical)
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.ui = load_ui('layout.ui', self,
+                          directory=os.path.dirname(__file__))
+
         self.image1 = WidgetWrapper(ImageViewer(self.session), tab_widget=self)
         self.image2 = WidgetWrapper(ImageViewer(self.session), tab_widget=self)
         self.image3 = WidgetWrapper(ImageViewer(self.session), tab_widget=self)
         self.specviz = WidgetWrapper(SpecVizViewer(self.session), tab_widget=self)
-        layout.addWidget(self.image1)
-        layout.addWidget(self.image2)
-        layout.addWidget(self.image3)
-        widget = QWidget()
-        widget.setLayout(layout)
-        self.addWidget(widget)
-        self.addWidget(self.specviz)
+
+        self.image1._widget.register_to_hub(self.session.hub)
+        self.image2._widget.register_to_hub(self.session.hub)
+        self.image3._widget.register_to_hub(self.session.hub)
+        self.specviz._widget.register_to_hub(self.session.hub)
+
+        self.ui.top_row_layout.addWidget(self.image1)
+        self.ui.top_row_layout.addWidget(self.image2)
+        self.ui.top_row_layout.addWidget(self.image3)
+
+        self.ui.bottom_row_layout.addWidget(self.specviz)
+
         self.subWindowActivated.connect(self._update_active_widget)
+
+        self.ui.bool_sync.clicked.connect(self._on_sync_change)
+        self.ui.button_toggle_sidebar.clicked.connect(self._toggle_sidebar)
+        self.sync = {}
+
+    def _toggle_sidebar(self, event=None):
+        splitter = self.session.application._ui.main_splitter
+        sizes = list(splitter.sizes())
+        if sizes[0] == 0:
+            sizes[0] += 10
+            sizes[1] -= 10
+        else:
+            sizes[1] = sizes[0] + sizes[1]
+            sizes[0] = 0
+        splitter.setSizes(sizes)
 
     def _update_active_widget(self, widget):
         self._active_widget = widget
@@ -66,3 +91,54 @@ class CubeVizLayout(QSplitter):
 
     def subWindowList(self):
         return [self.image1, self.image2, self.image3, self.specviz]
+
+    def setup_syncing(self):
+        for attribute in ['slices', 'x_min', 'x_max', 'y_min', 'y_max']:
+            sync1 = keep_in_sync(self.image1._widget.state, attribute,
+                                 self.image2._widget.state, attribute)
+            sync2 = keep_in_sync(self.image2._widget.state, attribute,
+                                 self.image3._widget.state, attribute)
+            self.sync[attribute] = sync1, sync2
+        self._on_sync_change()
+
+    def _on_sync_change(self, event=None):
+        if self.ui.bool_sync.isChecked():
+            for attribute in self.sync:
+                sync1, sync2 = self.sync[attribute]
+                sync1.enable_syncing()
+                sync2.enable_syncing()
+        else:
+            for attribute in self.sync:
+                sync1, sync2 = self.sync[attribute]
+                sync1.disable_syncing()
+                sync2.disable_syncing()
+
+
+@startup_action('cubeviz')
+def cubeviz_setup(session, data_collection):
+
+    app = session.application
+    cubeviz = app.add_fixed_layout_tab(CubeVizLayout)
+
+    app._ui.main_splitter.setSizes([0, 300])
+
+    app.close_tab(0, warn=False)
+
+    # TEMPORARY - generalize this
+    if len(data_collection) != 1:
+        raise Exception("The cubeviz loader requires exactly one dataset to be present")
+
+    data = data_collection[0]
+
+    # Automatically add data to viewers and set attribute for split viewers
+
+    image_viewers = cubeviz.image1._widget, cubeviz.image2._widget, cubeviz.image3._widget
+
+    for i, attribute in enumerate(['DATA', 'VAR', 'QUALITY']):
+        image_viewers[i].add_data(data)
+        state = image_viewers[i].state
+        state.aspect = 'auto'
+        state.layers[0].attribute = data.id[attribute]
+
+    # Set up linking of data slices and views
+    cubeviz.setup_syncing()

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -43,6 +43,59 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Show/hide specfic components in all viewers:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="toggle_flux">
+       <property name="text">
+        <string>Flux</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="toggle_error">
+       <property name="text">
+        <string>Error</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="toggle_quality">
+       <property name="text">
+        <string>Data Quality</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
@@ -64,60 +117,6 @@
         <string>Split image viewer</string>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Use the following buttons to show/hide specfic components in all viewers:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="toggle_flux">
-       <property name="text">
-        <string>Flux</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="toggle_error">
-       <property name="text">
-        <string>Error</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="toggle_quality">
-       <property name="text">
-        <string>Data Quality</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
      <item>
       <widget class="QToolButton" name="bool_sync">

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GlueApplication</class>
+ <widget class="QWidget" name="GlueApplication">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1027</width>
+    <height>586</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>3</number>
+   </property>
+   <property name="topMargin">
+    <number>3</number>
+   </property>
+   <property name="rightMargin">
+    <number>3</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="vertical_splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QWidget" name="toolbar">
+      <layout class="QHBoxLayout" name="toolbar_layout">
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <item>
+        <widget class="QToolButton" name="button_toggle_sidebar">
+         <property name="text">
+          <string>Toggle sidebar</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Use the following buttons to show/hide specfic components in all viewers:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="toolButton">
+         <property name="text">
+          <string>Flux</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="toolButton_2">
+         <property name="text">
+          <string>Error</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="toolButton_3">
+         <property name="text">
+          <string>Data Quality</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QToolButton" name="bool_sync">
+         <property name="text">
+          <string>Sync viewer slices/zoom</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="top_row">
+      <layout class="QHBoxLayout" name="top_row_layout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="bottom_row">
+      <layout class="QHBoxLayout" name="bottom_row_layout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1027</width>
+    <width>1130</width>
     <height>586</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
     <number>3</number>
    </property>
@@ -27,104 +27,131 @@
     <number>2</number>
    </property>
    <item>
-    <widget class="QSplitter" name="vertical_splitter">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <layout class="QHBoxLayout" name="toolbar_layout">
+     <property name="spacing">
+      <number>10</number>
      </property>
-     <widget class="QWidget" name="toolbar">
-      <layout class="QHBoxLayout" name="toolbar_layout">
-       <property name="spacing">
-        <number>10</number>
+     <item>
+      <widget class="QToolButton" name="button_toggle_sidebar">
+       <property name="text">
+        <string>Toggle sidebar</string>
        </property>
-       <item>
-        <widget class="QToolButton" name="button_toggle_sidebar">
-         <property name="text">
-          <string>Toggle sidebar</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Use the following buttons to show/hide specfic components in all viewers:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="toolButton">
-         <property name="text">
-          <string>Flux</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="toolButton_2">
-         <property name="text">
-          <string>Error</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="toolButton_3">
-         <property name="text">
-          <string>Data Quality</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="bool_sync">
-         <property name="text">
-          <string>Sync viewer slices/zoom</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_single_image">
+       <property name="text">
+        <string>Single image viewer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_split_image">
+       <property name="text">
+        <string>Split image viewer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Use the following buttons to show/hide specfic components in all viewers:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="toggle_flux">
+       <property name="text">
+        <string>Flux</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="toggle_error">
+       <property name="text">
+        <string>Error</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="toggle_quality">
+       <property name="text">
+        <string>Data Quality</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="bool_sync">
+       <property name="text">
+        <string>Sync viewer slices/zoom</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QSplitter" name="horizontal_splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="single_image">
+      <layout class="QHBoxLayout" name="single_image_layout"/>
      </widget>
-     <widget class="QWidget" name="top_row">
-      <layout class="QHBoxLayout" name="top_row_layout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="bottom_row">
-      <layout class="QHBoxLayout" name="bottom_row_layout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-      </layout>
+     <widget class="QSplitter" name="vertical_splitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <widget class="QWidget" name="image_row">
+       <layout class="QHBoxLayout" name="image_row_layout"/>
+      </widget>
+      <widget class="QWidget" name="specviz">
+       <layout class="QHBoxLayout" name="specviz_layout"/>
+      </widget>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
**Do not merge!**

**NOTE** the functionality here requires the ``qt-fixed-layout-tab`` branch of glue in my fork for now

This relies on unmerged functionality in the core glue package: https://github.com/glue-viz/glue/pull/1403

For now this doesn't yet add an entry point so one has to manually register this by adding:

```python
from cubeviz import layout
```

to a local ``config.py`` file. The result looks like this for now:

<img width="1680" alt="screen shot 2017-09-11 at 18 42 23" src="https://user-images.githubusercontent.com/314716/30300134-05598fa2-9721-11e7-9dea-d6df83e90965.png">

This doesn't yet do things like add data automatically to the viewers, or set up any kind of linking, but I plan on experimenting with that next.

We could then combine this with https://github.com/spacetelescope/cubeviz/pull/37 so that when launching ``cubeviz``, it would open glue with this layout by default