### PR TITLE
Prototype JWST data cube loader for glue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,17 @@ env:
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
+        - PYTEST_VERSION=3.1
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         - EVENT_TYPE='pull_request push'
 
-        
+
         # List other runtime dependencies for the package that are available as
         # conda packages here.
         - CONDA_DEPENDENCIES=''
-        
+
         # List other runtime dependencies for the package that are available as
         # pip packages here.
         # - PIP_DEPENDENCIES=''

--- a/config.py
+++ b/config.py
@@ -1,0 +1,3 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from cubeviz.utils.loader import read_jwst_data_cube, read_generic_data_cube

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from cubeviz import layout
 from cubeviz.utils.loader import read_jwst_data_cube, read_generic_data_cube

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -7,6 +7,3 @@ from glue.app.qt.application import GlueApplication
 def main():
     app = GlueApplication()
     sys.exit(app.start())
-
-if __name__ == '__main__':
-    main()

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -5,7 +5,7 @@ from glue.app.qt.application import GlueApplication
 
 
 def setup():
-    pass
+    from cubeviz.utils.loader import read_jwst_data_cube
 
 def main():
     app = GlueApplication()

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -4,6 +4,9 @@ import sys
 from glue.app.qt.application import GlueApplication
 
 
+def setup():
+    pass
+
 def main():
     app = GlueApplication()
     sys.exit(app.start())

--- a/cubeviz/main.py
+++ b/cubeviz/main.py
@@ -1,0 +1,12 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
+
+from glue.app.qt.application import GlueApplication
+
+
+def main():
+    app = GlueApplication()
+    sys.exit(app.start())
+
+if __name__ == '__main__':
+    main()

--- a/cubeviz/setup_package.py
+++ b/cubeviz/setup_package.py
@@ -1,0 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+def get_package_data():
+    return {'cubeviz': ['layout.ui']}

--- a/cubeviz/utils/loader.py
+++ b/cubeviz/utils/loader.py
@@ -2,21 +2,70 @@
 
 from glue.config import data_factory
 from glue.core import Data
+from astropy.io import fits
+
 import asdf
+from asdf.fits_embed import ASDF_EXTENSION_NAME
 
 
-def is_jwst_data_cube(filename, **kwargs):
-    return filename.endswith('.asdf')
+def _is_jwst_asdf_cube(asdffile):
+    meta = asdffile.tree.get('meta')
+    if meta is None:
+        return False
 
-def is_generic_data_cube(filename, **kwargs):
+    instrument = meta.get('instrument')
+    if instrument is None:
+        return False
+
+    name = instrument.get('name')
+    detector = instrument.get('detector')
+    if name is None or detector is None:
+        return False
+    if name != 'NIRSPEC' or not detector.startswith('NRS'):
+        return False
+
+    for array_name in ['data', 'dq', 'err']:
+        if array_name not in asdffile.tree:
+            return False
+
+    return True
+
+def _is_jwst_fits_cube(hdulist):
     pass
 
+def is_jwst_data_cube(filename, **kwargs):
+    if filename.endswith('.asdf'):
+        try:
+            with asdf.open(filename) as af:
+                return _is_jwst_asdf_cube(af)
+        except ValueError:
+            return False
+    elif filename.endswith('.fits'):
+        try:
+            with fits.open(filename) as hdulist:
+                # Check whether this is an ASDF file embedded in FITS
+                if ASDF_EXTENSION_NAME in hdulist:
+                    with asdf.open(hdulist) as af:
+                        return _is_jwst_asdf_cube(af)
+                # Otherwise treat it as a regular FITS file
+                return _is_jwst_fits_cube(hdulist)
+        except ValueError:
+            return False
 
-@data_factory('JWST data cube loader', is_jwst_data_cube, priority=1100)
+    return False
+
+def is_generic_data_cube(filename, **kwargs):
+    # It's not clear whether there's a way to detect this automatically
+    return False
+
+@data_factory('JWST data cube loader', is_jwst_data_cube, priority=1200)
 def read_jwst_data_cube(filename):
     asdffile = asdf.open(filename)
-    return Data(data=asdffile.tree['data'])
+    return Data(
+        data=asdffile.tree['data'],
+        dq=asdffile.tree['dq'],
+        err=asdffile.tree['err'])
 
-@data_factory('Generic data cube loader', is_generic_data_cube, priority=1099)
+@data_factory('Generic data cube loader')
 def read_generic_data_cube(filename):
     pass

--- a/cubeviz/utils/loader.py
+++ b/cubeviz/utils/loader.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from glue.config import data_factory
+from glue.config import data_factory, set_startup_action
 from glue.core import Data
 from astropy.io import fits
 
@@ -87,6 +87,9 @@ def _load_jwst_asdf(fileobj):
 
 @data_factory('JWST data cube loader', is_jwst_data_cube, priority=1200)
 def read_jwst_data_cube(filename):
+    # This loads the cubeviz-specific layout
+    set_startup_action('cubeviz')
+
     # Process ASDF files
     if filename.endswith('asdf'):
         return _load_jwst_asdf(filename)

--- a/cubeviz/utils/loader.py
+++ b/cubeviz/utils/loader.py
@@ -29,7 +29,26 @@ def _is_jwst_asdf_cube(asdffile):
     return True
 
 def _is_jwst_fits_cube(hdulist):
-    pass
+    if 'PRIMARY' not in hdulist:
+        return False
+
+    primary = hdulist['PRIMARY'].header
+
+    if 'TELESCOP' not in primary:
+        return False
+    if not primary['TELESCOP'].startswith('JWST'):
+        return False
+
+    if 'DATAMODL' not in primary:
+        return False
+    if not primary['DATAMODL'] == 'IFUCubeModel':
+        return False
+
+    for extname in ['SCI', 'ERR', 'DQ']:
+        if extname not in hdulist:
+            return False
+
+    return True
 
 def is_jwst_data_cube(filename, **kwargs):
     if filename.endswith('.asdf'):

--- a/cubeviz/utils/loader.py
+++ b/cubeviz/utils/loader.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from glue.config import data_factory
+from glue.core import Data
+import asdf
+
+
+def is_jwst_data_cube(filename, **kwargs):
+    return filename.endswith('.asdf')
+
+def is_generic_data_cube(filename, **kwargs):
+    pass
+
+
+@data_factory('JWST data cube loader', is_jwst_data_cube, priority=1100)
+def read_jwst_data_cube(filename):
+    asdffile = asdf.open(filename)
+    return Data(data=asdffile.tree['data'])
+
+@data_factory('Generic data cube loader', is_generic_data_cube, priority=1099)
+def read_generic_data_cube(filename):
+    pass

--- a/cubeviz/utils/loader.py
+++ b/cubeviz/utils/loader.py
@@ -13,16 +13,14 @@ def _is_jwst_asdf_cube(asdffile):
     if meta is None:
         return False
 
-    instrument = meta.get('instrument')
-    if instrument is None:
+    if meta.get('telescope') != 'JWST':
         return False
 
-    name = instrument.get('name')
-    detector = instrument.get('detector')
-    if name is None or detector is None:
+    if meta.get('model_type') != 'IFUCubeModel':
         return False
-    if name != 'NIRSPEC' or not detector.startswith('NRS'):
-        return False
+
+    # Other possible checks to use:
+    #   meta['exposure']['type'] == 'NRS_IFU' # (for NIRSpec)
 
     for array_name in ['data', 'dq', 'err']:
         if array_name not in asdffile.tree:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1
+install_requires = astropy asdf pytest==3.1
 
 [entry_points]
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,10 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'gui_scripts': ['cubeviz=cubeviz.cubeviz:main']}
+entry_points = {
+    'gui_scripts': ['cubeviz=cubeviz.cubeviz:main'],
+    'glue.plugins': ['cubeviz=cubeviz.cubeviz:setup']
+}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'console_scripts': []}
+entry_points = {'console_scripts': ['cubeviz=cubeviz.main:main']}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,11 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
+# I'm not sure whether it makes sense to duplicate this here or not
+default_install_requires = 'astropy asdf pytest==3.1'
+install_requires = metadata.get(
+    'install_requires', default_install_requires).strip().split()
+
 # Note that requires and provides should not be included in the call to
 # ``setup``, since these are now deprecated. See this link for more details:
 # https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
@@ -129,7 +134,7 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      install_requires=metadata.get('install_requires', 'astropy').strip().split(),
+      install_requires=install_requires,
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'console_scripts': ['cubeviz=cubeviz.cubeviz:main']}
+entry_points = {'gui_scripts': ['cubeviz=cubeviz.cubeviz:main']}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
-entry_points = {'console_scripts': ['cubeviz=cubeviz.main:main']}
+entry_points = {'console_scripts': ['cubeviz=cubeviz.cubeviz:main']}
 
 if conf.has_section('entry_points'):
     entry_point_list = conf.items('entry_points')


### PR DESCRIPTION
This PR contains prototype logic for recognizing JWST data cubes (in both ASDF and FITS formats) and loading them as a glue data set. The file recognition uses some pretty simple heuristics that will probably need to be updated/enhanced at some point.

I'm not sure if I'm loading the data correctly at this point, but in any case this will need to be integrated with the work that has been done on glue dashboards in #38.