### PR TITLE
UI Updates

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -110,8 +110,8 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._last_click = None
         self._active_widget = None
 
-        self._single_image = True
-        self.ui.button_toggle_image_mode.setText('Split Image Viewer')
+        self._single_image = False
+        self.ui.button_toggle_image_mode.setText('Single Image Viewer')
 
     def _toggle_flux(self, event=None):
         self.image1._widget.state.layers[0].visible = self.ui.toggle_flux.isChecked()
@@ -237,5 +237,6 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def showEvent(self, event):
         super(CubeVizLayout, self).showEvent(event)
-        self._single_image_mode()
-        self._update_active_widget(self.image1)
+        # Make split image mode the default layout
+        self._split_image_mode()
+        self._update_active_widget(self.image2)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -55,6 +55,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         super(CubeVizLayout, self).__init__(parent=parent)
 
         self.session = session
+        self._wavelengths = None
 
         self.ui = load_ui('layout.ui', self,
                           directory=os.path.dirname(__file__))
@@ -134,10 +135,18 @@ class CubeVizLayout(QtWidgets.QWidget):
             z, y, x = image._widget.state.slices
             image._widget.state.slices = (value, y, x)
 
-    def set_nslices(self, nslices):
+        self.ui.text_slice.setText(str(value))
+        self.ui.text_wavelength.setText(str(self._wavelengths[value]))
+
+    def initialize_slider(self):
         self.ui.value_slice.setEnabled(True)
         self.ui.value_slice.setMinimum(0)
-        self.ui.value_slice.setMaximum(nslices-1)
+
+        self._wavelengths = self.image1._widget._data[0].get_component('Wave')[:,0,0]
+        self.ui.value_slice.setMaximum(len(self._wavelengths) - 1)
+
+        self.ui.text_slice.setText('0')
+        self.ui.text_wavelength.setText(str(self._wavelengths[0]))
 
     def eventFilter(self, obj, event):
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -181,8 +181,10 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._wavelengths = self.image1._widget._data[0].get_component('Wave')[:,0,0]
         self.ui.value_slice.setMaximum(len(self._wavelengths) - 1)
 
-        self.ui.text_slice.setText('0')
-        self.ui.text_wavelength.setText(str(self._wavelengths[0]))
+        # Set the default display to the middle of the cube
+        middle_index = len(self._wavelengths) // 2
+        self._update_slice(middle_index)
+        self.ui.value_slice.setValue(middle_index)
 
     def eventFilter(self, obj, event):
 

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -99,10 +99,30 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="text_slice"/>
+      <widget class="QLineEdit" name="text_slice">
+       <property name="maximumSize">
+        <size>
+         <width>50</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>slice #</string>
+       </property>
+      </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="text_wavelength"/>
+      <widget class="QLineEdit" name="text_wavelength">
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>wavelength</string>
+       </property>
+      </widget>
      </item>
      <item>
       <spacer name="horizontalSpacer">

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -55,13 +55,6 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Show/hide specfic components in all viewers:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QToolButton" name="toggle_flux">
        <property name="text">
         <string>Flux</string>
@@ -104,6 +97,12 @@
         <enum>Qt::Horizontal</enum>
        </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="text_slice"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="text_wavelength"/>
      </item>
      <item>
       <spacer name="horizontalSpacer">

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -72,7 +72,7 @@ class CubevizManager(HubListener):
         # Set up linking of data slices and views
         cubeviz_layout.setup_syncing()
 
-        cubeviz_layout.set_nslices(data.shape[0])
+        cubeviz_layout.initialize_slider()
 
         index = self._app.get_tab_index(cubeviz_layout)
         self._app.tab_bar.rename_tab(index, "CubeViz: {}".format(data.label))


### PR DESCRIPTION
@brechmos-stsci and I worked on some UI updates today, including the following:

* change default layout from single image viewer to split image viewer
* display wavelength and slice index next to slider bar
* navigate to a different slice by entering either a wavelength or a slice index
* show the slice in the middle of the cube at startup

It was good to refresh ourselves with `glue` and `cubeviz` UI development, and hopefully these changes will invite further discussion about UI issues.

This fixes #44 and fixes #46.