### PR TITLE
Make it so that cubeviz command implicitly adds --startup=cubeviz

### DIFF
--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -1,14 +1,23 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 
-from glue.app.qt.application import GlueApplication
+from glue.main import main as glue_main
 
 
 def setup():
-    from . import data_factories
-    from . import layout
-    from . import startup
+    from . import data_factories  # noqa
+    from . import layout  # noqa
+    from . import startup  # noqa
 
-def main():
-    app = GlueApplication()
-    sys.exit(app.start())
+
+def main(argv=sys.argv):
+
+    for i in range(len(argv)):
+        if argv[i].startswith('--startup'):
+            if 'cubeviz' not in argv[i]:
+                argv[i] = argv[i] + ',cubeviz'
+            break
+    else:
+        argv.append('--startup=cubeviz')
+
+    sys.exit(glue_main(argv))


### PR DESCRIPTION
Otherwise any other arguments are passed on to the glue command, meaning it's still possible to pass filenames etc.