### PR TITLE
Updates to the way that viewers are synced

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -5,7 +5,8 @@ from collections import OrderedDict
 
 import numpy as np
 
-from glue.config import qt_fixed_layout_tab
+from glue.config import qt_fixed_layout_tab, viewer_tool
+from glue.viewers.common.qt.tool import CheckableTool
 from qtpy import QtWidgets, QtCore
 from qtpy.QtWidgets import QMenu, QAction
 from glue.viewers.image.qt import ImageViewer
@@ -24,11 +25,39 @@ COLOR[ERROR] = '#ffaa66'
 COLOR[MASK] = '#66aaff'
 
 
+@viewer_tool
+class SyncButtonBox(CheckableTool):
+
+    icon = 'glue_link'
+    tool_id = 'sync_checkbox'
+    action_text = 'Sync this viewer with other viewers'
+    tool_tip = 'Sync this viewer with other viewers'
+    status_tip = 'This viewer is synced'
+    shortcut = 'D'
+
+    def __init__(self, viewer):
+        super(SyncButtonBox, self).__init__(viewer)
+        self._synced = True
+
+    def activate(self):
+        self._synced = True
+
+    def deactivate(self):
+        self._synced = False
+
+    def close(self):
+        pass
+
+
 class CubevizImageViewer(ImageViewer):
 
-    tools = ['select:rectangle', 'select:xrange',
+    tools = ['sync_checkbox', 'select:rectangle', 'select:xrange',
              'select:yrange', 'select:circle',
              'select:polygon', 'image:contrast_bias']
+
+    def __init__(self, *args, **kwargs):
+        super(CubevizImageViewer, self).__init__(*args, **kwargs)
+        self._sync_button = SyncButtonBox(self)
 
 
 class WidgetWrapper(QtWidgets.QWidget):

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -272,7 +272,7 @@
      <item row="1" column="12">
       <widget class="QToolButton" name="bool_sync">
        <property name="text">
-        <string>Sync viewer slices/zoom</string>
+        <string>Sync Viewers</string>
        </property>
        <property name="checkable">
         <bool>true</bool>

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -270,12 +270,15 @@
       </spacer>
      </item>
      <item row="1" column="12">
-      <widget class="QToolButton" name="bool_sync">
+      <widget class="QToolButton" name="sync_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
         <string>Sync Viewers</string>
        </property>
        <property name="checkable">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="checked">
         <bool>false</bool>


### PR DESCRIPTION
This PR adds a toggle button to each of the images viewers controlling whether a particular viewer is synced or not. This allows viewers to be controlled independently when necessary. The `Sync Viewers` button in the cubeviz toolbar now syncs all of the viewers with the active viewer.

This PR currently disables glue-level syncing between viewers since it is now controlled by the CubeViz UI. There may be a way to integrate this nicely with glue again. It will be necessary to update this eventually so that the viewer axes can be resynced if desired.

Submitting jointly with @brechmos-stsci 