### PR TITLE
Listen and add new components to layout dropdown.

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -250,7 +250,6 @@ class CubeVizLayout(QtWidgets.QWidget):
         return menu_widget
 
     def _open_dialog(self, name, widget):
-        #get_text(name, "What's your name?")
         if name == "Filter":
             ex = smoothing_gui.SelectSmoothing(
                 self._data, 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -250,16 +250,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         return menu_widget
 
     def _open_dialog(self, name, widget):
-        if name == "Filter":
-            ex = smoothing_gui.SelectSmoothing(
-                self._data, 
-                self.session.data_collection,
-                parent=self
-                ) 
-    def add_smoothed_cube_name(self, name):
-        for i, combo in enumerate(self._viewer_combos):
-            combo.addItem(name)
-        self._component_labels.append(name)
+        pass 
 
     def _enable_option_buttons(self):
         for button in self._option_buttons:

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division
 
 import os
-import copy
 from collections import OrderedDict
 
 import numpy as np
@@ -186,7 +185,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Add menu buttons to the cubeviz toolbar.
         self._init_menu_buttons()
 
-        self._component_labels = copy.copy(DEFAULT_DATA_LABELS)
+        self._component_labels = DEFAULT_DATA_LABELS.copy()
 
         self.sync = {}
 
@@ -250,7 +249,12 @@ class CubeVizLayout(QtWidgets.QWidget):
         return menu_widget
 
     def _open_dialog(self, name, widget):
-        pass 
+        pass
+        
+    def add_smoothed_cube_name(self, name):
+        for i, combo in enumerate(self._viewer_combos):
+            combo.addItem(name)
+        self._component_labels.append(name)
 
     def _enable_option_buttons(self):
         for button in self._option_buttons:

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -254,7 +254,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             ex = smoothing_gui.SelectSmoothing(
                 self._data, 
                 self.session.data_collection,
-                parent=self#self.session.application
+                parent=self
                 ) 
     def add_smoothed_cube_name(self, name):
         for i, combo in enumerate(self._viewer_combos):

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 import os
+import copy
 from collections import OrderedDict
 
 import numpy as np
@@ -15,10 +16,13 @@ from glue.utils.qt import load_ui, get_text
 from glue.external.echo import keep_in_sync
 from glue.utils.qt import get_qapp
 
+from .tools import smoothing_gui
+
+
 FLUX = 'FLUX'
 ERROR = 'ERROR'
 MASK = 'MASK'
-DATA_LABELS = [FLUX, ERROR, MASK]
+DEFAULT_DATA_LABELS = [FLUX, ERROR, MASK]
 
 COLOR = {}
 COLOR[FLUX] = '#888888'
@@ -182,6 +186,8 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Add menu buttons to the cubeviz toolbar.
         self._init_menu_buttons()
 
+        self._component_labels = copy.copy(DEFAULT_DATA_LABELS)
+
         self.sync = {}
 
         app = get_qapp()
@@ -244,7 +250,17 @@ class CubeVizLayout(QtWidgets.QWidget):
         return menu_widget
 
     def _open_dialog(self, name, widget):
-        get_text(name, "What's your name?")
+        #get_text(name, "What's your name?")
+        if name == "Filter":
+            ex = smoothing_gui.SelectSmoothing(
+                self._data, 
+                self.session.data_collection,
+                parent=self#self.session.application
+                ) 
+    def add_smoothed_cube_name(self, name):
+        for i, combo in enumerate(self._viewer_combos):
+            combo.addItem(name)
+        self._component_labels.append(name)
 
     def _enable_option_buttons(self):
         for button in self._option_buttons:
@@ -376,7 +392,7 @@ class CubeVizLayout(QtWidgets.QWidget):
     def _get_change_viewer_func(self, view_index):
         def change_viewer(dropdown_index):
             view = self.cubes[view_index]
-            label = DATA_LABELS[dropdown_index]
+            label = self._component_labels[dropdown_index]
             view._widget.state.layers[0].attribute = self._data.id[label]
         return change_viewer
 


### PR DESCRIPTION
This PR separates the smoothing function from this feature in PR #108 (I will be making another PR for smoothing functions). In this PR, `listener.py` subscribes to `DataAddComponentMessage`. When a new component is added to a glue object, the emitted message is processed and `layout.add_smoothed_cube_name` is called to append the the `component_id` to the drop down list.