### PR TITLE
Update requirements for glue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1
-install_requires = numpy>=1.13 astropy asdf pytest==3.1 glueviz>=0.13
+install_requires = numpy>=1.13 astropy asdf pytest==3.1 glue-core>=0.13 glueviz
 
 [entry_points]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1
-install_requires = numpy>=1.13 astropy asdf pytest==3.1 glue-core>=0.13 glueviz
+install_requires = numpy>=1.13 astropy asdf pytest==3.1 glue-core>=0.12 glueviz
 
 [entry_points]
 

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -26,7 +26,7 @@ dependencies:
   # This is necessary in some OSX environments to ensure that Python is
   # installed as a framework
   - matplotlib
-  - glue-core>=0.12.999
+  - glue-core>=0.12
   - glueviz
   - pip:
     - git+https://github.com/spacetelescope/specviz#egg=specviz

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -26,6 +26,7 @@ dependencies:
   # This is necessary in some OSX environments to ensure that Python is
   # installed as a framework
   - matplotlib
+  - glue-core>=0.12.999
   - glueviz
   - pip:
     - git+https://github.com/spacetelescope/specviz#egg=specviz


### PR DESCRIPTION
The requirement on the version of glue is really related to glue-core not glueviz. But by depending on glueviz we also get the 3D viewers, so this adds a requirement on glue-core>=0.13 and also keeps glueviz without version requirements. Note that the use of 0.12.999 for the conda file is because conda doesn't consider 0.13.dev0 > 0.13