### PR TITLE
Split out custom image viewer into separate file

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -1,0 +1,78 @@
+# This file contains a sub-class of the glue image viewer with further
+# customizations.
+
+from __future__ import print_function, division
+
+from glue.config import viewer_tool
+from glue.viewers.common.qt.tool import CheckableTool
+from glue.viewers.image.qt import ImageViewer
+
+
+__all__ = ['CubevizImageViewer']
+
+
+@viewer_tool
+class SyncButtonBox(CheckableTool):
+    """
+    SyncButtonBox derived from the Glue CheckableTool that will be placed on the
+    Matplotlib toolbar in order to allow syncing between the different views in
+    cubeviz.
+
+    We need to store the "synced" state of this button so that we can check it
+    in other parts of the code.
+    """
+
+    icon = 'glue_link'
+    tool_id = 'sync_checkbox'
+    action_text = 'Sync this viewer with other viewers'
+    tool_tip = 'Sync this viewer with other viewers'
+    status_tip = 'This viewer is synced'
+    shortcut = 'D'
+
+    def __init__(self, viewer):
+        super(SyncButtonBox, self).__init__(viewer)
+        self._synced = True
+
+    def activate(self):
+        self._synced = True
+
+    def deactivate(self):
+        self._synced = False
+
+    def close(self):
+        pass
+
+
+class CubevizImageViewer(ImageViewer):
+
+    # Add the sync button to the front of the list so it is more prominent
+    # on smaller screens.
+    tools = ['sync_checkbox', 'select:rectangle', 'select:xrange',
+             'select:yrange', 'select:circle',
+             'select:polygon', 'image:contrast_bias']
+
+    def __init__(self, *args, **kwargs):
+        super(CubevizImageViewer, self).__init__(*args, **kwargs)
+        self._sync_button = None
+        self._slice_index = None
+
+    def enable_toolbar(self):
+        self._sync_button = self.toolbar.tools[SyncButtonBox.tool_id]
+        self.enable_button()
+
+    def enable_button(self):
+        button = self.toolbar.actions[SyncButtonBox.tool_id]
+        button.setChecked(True)
+
+    def update_slice_index(self, index):
+        self._slice_index = index
+        z, y, x = self.state.slices
+        self.state.slices = (self._slice_index, y, x)
+
+    @property
+    def synced(self):
+        return self._sync_button._synced
+
+    @property
+    def slice_index(self):
+        return self._slice_index

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -5,16 +5,15 @@ from collections import OrderedDict
 
 import numpy as np
 
-from glue.config import qt_fixed_layout_tab, viewer_tool
-from glue.viewers.common.qt.tool import CheckableTool
+from glue.config import qt_fixed_layout_tab
 from qtpy import QtWidgets, QtCore
 from qtpy.QtWidgets import QMenu, QAction
-from glue.viewers.image.qt import ImageViewer
 from specviz.third_party.glue.data_viewer import SpecVizViewer
-from glue.utils.qt import load_ui, get_text
+from glue.utils.qt import load_ui
 from glue.external.echo import keep_in_sync
 from glue.utils.qt import get_qapp
 
+from .image_viewer import CubevizImageViewer
 
 FLUX = 'FLUX'
 ERROR = 'ERROR'
@@ -25,71 +24,6 @@ COLOR = {}
 COLOR[FLUX] = '#888888'
 COLOR[ERROR] = '#ffaa66'
 COLOR[MASK] = '#66aaff'
-
-
-@viewer_tool
-class SyncButtonBox(CheckableTool):
-    """
-    SyncButtonBox derived from the Glue CheckableTool that will be placed on the Matplotlib toolbar
-    in order to allow syncing between the different views in cubeviz.
-
-    We need to store the "synced" state of this button so that we can check it in other parts of the code.
-    """
-
-    icon = 'glue_link'
-    tool_id = 'sync_checkbox'
-    action_text = 'Sync this viewer with other viewers'
-    tool_tip = 'Sync this viewer with other viewers'
-    status_tip = 'This viewer is synced'
-    shortcut = 'D'
-
-    def __init__(self, viewer):
-        super(SyncButtonBox, self).__init__(viewer)
-        self._synced = True
-
-    def activate(self):
-        self._synced = True
-
-    def deactivate(self):
-        self._synced = False
-
-    def close(self):
-        pass
-
-
-class CubevizImageViewer(ImageViewer):
-
-    # Add the sync button to the front of the list so it is more prominent
-    # on smaller screens.
-    tools = ['sync_checkbox', 'select:rectangle', 'select:xrange',
-             'select:yrange', 'select:circle',
-             'select:polygon', 'image:contrast_bias']
-
-    def __init__(self, *args, **kwargs):
-        super(CubevizImageViewer, self).__init__(*args, **kwargs)
-        self._sync_button = None
-        self._slice_index = None
-
-    def enable_toolbar(self):
-        self._sync_button = self.toolbar.tools[SyncButtonBox.tool_id]
-        self.enable_button()
-
-    def enable_button(self):
-        button = self.toolbar.actions[SyncButtonBox.tool_id]
-        button.setChecked(True)
-
-    def update_slice_index(self, index):
-        self._slice_index = index
-        z, y, x = self.state.slices
-        self.state.slices = (self._slice_index, y, x)
-
-    @property
-    def synced(self):
-        return self._sync_button._synced
-
-    @property
-    def slice_index(self):
-        return self._slice_index
 
 
 class WidgetWrapper(QtWidgets.QWidget):
@@ -248,7 +182,7 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def _open_dialog(self, name, widget):
         pass
-        
+
     def add_smoothed_cube_name(self, name):
         for i, combo in enumerate(self._viewer_combos):
             combo.addItem(name)
@@ -359,7 +293,7 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def _enable_slider(self):
         """
-        Setup the slice slider (min/max, units on description and initial position). 
+        Setup the slice slider (min/max, units on description and initial position).
 
         :return:
         """


### PR DESCRIPTION
To keep files from growing too much, I think it'd make sense to split out the custom image viewer stuff into its own file.