### PR TITLE
WIP: More layout and UI improvements

### DIFF
--- a/cubeviz/controls/overlay.py
+++ b/cubeviz/controls/overlay.py
@@ -10,7 +10,7 @@ class OverlayController:
 
     def __init__(self, cubeviz_layout):
         self._cv_layout = cubeviz_layout
-        self._cubes = cubeviz_layout.cubes
+        self._cube_views = cubeviz_layout.cube_views
         ui = cubeviz_layout.ui
 
         self._overlays = Data('Overlays')
@@ -64,7 +64,7 @@ class OverlayController:
         for cb in self._overlay_colorbar_axis:
             for cbim in cb.get_images():
                 cbim.set_cmap(colormap)
-        for cube in self._cubes:
+        for cube in self._cube_views:
             cube._widget.figure.canvas.draw()
 
     def _draw_mpl_overlay(self, data, view):
@@ -97,7 +97,7 @@ class OverlayController:
         # Remove all existing overlays
         if self._active_overlays:
             for overlay, view, cb in zip(
-                    self._active_overlays, self._cubes, self._overlay_colorbar_axis):
+                    self._active_overlays, self._cube_views, self._overlay_colorbar_axis):
                 overlay.remove()
                 cb.remove()
                 view._widget.figure.canvas.draw()
@@ -110,7 +110,7 @@ class OverlayController:
             return
 
         self._active_overlays = []
-        for view in self._cubes:
+        for view in self._cube_views:
             self._draw_mpl_overlay(data, view)
 
         self._alpha_slider.setValue(25)

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -78,7 +78,7 @@ class SliceController:
         :return:
         """
         index = self._slice_slider.value()
-        all_cubes = self._cv_layout.cubes
+        cube_views = self._cv_layout.cube_views
         active_cube = self._cv_layout._active_cube
         active_widget = active_cube._widget
 
@@ -88,9 +88,9 @@ class SliceController:
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
         if active_widget.synced:
-            for cube in all_cubes:
-                if cube != active_cube and cube._widget.synced:
-                    cube._widget.update_slice_index(index)
+            for view in cube_views:
+                if view != active_cube and view._widget.synced:
+                    view._widget.update_slice_index(index)
             self._cv_layout.synced_index = index
 
         # Now update the slice and wavelength text boxes

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -87,7 +87,7 @@ class SliceController:
 
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
-        if active_widget.synced:
+        if active_widget.synced and not self._cv_layout._single_viewer_mode:
             for view in cube_views:
                 if view != active_cube and view._widget.synced:
                     view._widget.update_slice_index(index)

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -82,9 +82,9 @@ class CubevizImageViewer(ImageViewer):
     def enable_toolbar(self):
         self._sync_button = self.toolbar.tools[SyncButtonBox.tool_id]
         self._sync_button._hub = self.parent().tab_widget.session.hub
-        self.enable_button()
+        self.set_sync_button()
 
-    def enable_button(self):
+    def set_sync_button(self):
         button = self.toolbar.actions[SyncButtonBox.tool_id]
         button.setChecked(True)
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -143,8 +143,10 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._active_view = None
         self._active_cube = None
 
+        # Set the default to parallel image viewer
         self._single_image = False
         self.ui.button_toggle_image_mode.setText('Single Image Viewer')
+        self.ui.viewer_control_frame.setCurrentIndex(0)
 
     def _init_menu_buttons(self):
         """
@@ -362,10 +364,12 @@ class CubeVizLayout(QtWidgets.QWidget):
             self._split_image_mode(event)
             self._single_image = False
             self.ui.button_toggle_image_mode.setText('Single Image Viewer')
+            self.ui.viewer_control_frame.setCurrentIndex(0)
         else:
             self._single_image_mode(event)
             self._single_image = True
             self.ui.button_toggle_image_mode.setText('Split Image Viewer')
+            self.ui.viewer_control_frame.setCurrentIndex(1)
 
     def _single_image_mode(self, event=None):
         vsplitter = self.ui.vertical_splitter

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -315,8 +315,9 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._data = data
         self.specviz._widget.add_data(data)
 
-        for view in self.views:
-            view._widget.enable_toolbar()
+        # Syncing should only be enabled by default for cube viewers
+        for cube in self.cubes:
+            cube._widget.enable_toolbar()
 
         self._has_data = True
         self._active_view = self.left_view

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -136,6 +136,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Add menu buttons to the cubeviz toolbar.
         self._init_menu_buttons()
 
+        # This maps the combo box indicies to the glue data component labels
         self._component_labels = DEFAULT_DATA_LABELS.copy()
 
         self.sync = {}
@@ -249,8 +250,6 @@ class CubeVizLayout(QtWidgets.QWidget):
                 self._data, self.session.data_collection, parent=self)
 
     def add_new_data_component(self, name):
-        for i, combo in enumerate(self._viewer_combos):
-            combo.addItem(str(name))
         self._component_labels.append(str(name))
 
         # TODO: udpate the active view with the new component

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -9,7 +9,9 @@ from qtpy.QtWidgets import QMenu, QAction
 from glue.utils.qt import load_ui
 from glue.utils.qt import get_qapp
 from glue.config import qt_fixed_layout_tab
-from glue.external.echo import keep_in_sync
+from glue.external.echo import keep_in_sync, SelectionCallbackProperty
+from glue.external.echo.qt import connect_combo_selection
+from glue.core.data_combo_helper import ComponentIDComboHelper
 from glue.core.message import SettingsChangeMessage
 
 from specviz.third_party.glue.data_viewer import SpecVizViewer
@@ -55,6 +57,10 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     LABEL = "CubeViz"
     subWindowActivated = QtCore.Signal(object)
+
+    viewer1_attribute = SelectionCallbackProperty(default_index=0)
+    viewer2_attribute = SelectionCallbackProperty(default_index=1)
+    viewer3_attribute = SelectionCallbackProperty(default_index=2)
 
     def __init__(self, session=None, parent=None):
         super(CubeVizLayout, self).__init__(parent=parent)
@@ -270,7 +276,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             view._widget.state.layers[0].attribute = self._data.id[label]
         return change_viewer
 
-    def _enable_viewer_combos(self):
+    def _enable_viewer_combos(self, data):
         """
         Setup the dropdown boxes that correspond to each of the left, middle, and right views.  The combo boxes
         initially are set to have FLUX, Error, DQ but will be dynamic depending on the type of data available either
@@ -278,23 +284,17 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         :return:
         """
-
-        self._viewer_combos = [
-            self.ui.viewer1_combo,
-            self.ui.viewer2_combo,
-            self.ui.viewer3_combo
-        ]
-
-        # Add the options to each of the dropdowns.
-        # TODO: Maybe should make this a function of the loaded data.
-        for i, combo in enumerate(self._viewer_combos):
-            for item in ['Flux', 'Error', 'DQ']:
-                combo.addItem(item)
+        self._viewer_combos = []
+        self._viewer_combo_helpers = []
+        for i in range(3):
+            combo = getattr(self.ui, 'viewer{0}_combo'.format(i+1))
+            connect_combo_selection(self, 'viewer{0}_attribute'.format(i+1), combo)
+            helper = ComponentIDComboHelper(self, 'viewer{0}_attribute'.format(i+1))
+            helper.set_multiple_data([data])
             combo.setEnabled(True)
             combo.currentIndexChanged.connect(self._get_change_viewer_func(i))
-
-            # First view will be flux, second error and third DQ.
-            combo.setCurrentIndex(i)
+            self._viewer_combos.append(combo)
+            self._viewer_combo_helpers.append(helper)
 
     def add_overlay(self, data, label):
         self._overlay_controller.add_overlay(data, label)
@@ -316,8 +316,6 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._active_view = self.left_view
         self._active_cube = self.left_view
 
-        self._enable_viewer_combos()
-
         # Store pointer to wavelength information
         self._wavelengths = self.single_view._widget._data[0].get_component('Wave')[:,0,0]
 
@@ -327,6 +325,8 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         self._enable_option_buttons()
         self._setup_syncing()
+
+        self._enable_viewer_combos(data)
 
         self.subWindowActivated.emit(self._active_view)
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -114,6 +114,12 @@ class CubeVizLayout(QtWidgets.QWidget):
         # This tracks the current positions of cube viewer axes when they are hidden
         self._viewer_axes_positions = []
 
+        # This is a list of helpers for the viewer combo boxes. New data
+        # collections should be added to each helper in this list using the
+        # ``append_data`` method to ensure that the new data components are
+        # populated into the combo boxes.
+        self._viewer_combo_helpers = []
+
         # Indicates whether cube viewer toolbars are currently visible or not
         self._toolbars_visible = True
 
@@ -260,6 +266,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         helper.set_multiple_data([data])
         combo.setEnabled(True)
         combo.currentIndexChanged.connect(self._get_change_viewer_func(index))
+        self._viewer_combo_helpers.append(helper)
 
     def _enable_all_viewer_combos(self, data):
         """

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -58,6 +58,7 @@ class CubeVizLayout(QtWidgets.QWidget):
     LABEL = "CubeViz"
     subWindowActivated = QtCore.Signal(object)
 
+    single_viewer_attribute = SelectionCallbackProperty(default_index=0)
     viewer1_attribute = SelectionCallbackProperty(default_index=0)
     viewer2_attribute = SelectionCallbackProperty(default_index=1)
     viewer3_attribute = SelectionCallbackProperty(default_index=2)
@@ -270,30 +271,36 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def _get_change_viewer_func(self, view_index):
         def change_viewer(dropdown_index):
-            view = self.cubes[view_index]
+            view = self.views[view_index]
             label = self._component_labels[dropdown_index]
             view._widget.state.layers[0].attribute = self._data.id[label]
         return change_viewer
 
-    def _enable_viewer_combos(self, data):
+    def _enable_viewer_combo(self, data, index, combo_label, selection_label):
+        combo = getattr(self.ui, combo_label)
+        connect_combo_selection(self, selection_label, combo)
+        helper = ComponentIDComboHelper(self, selection_label)
+        helper.set_multiple_data([data])
+        combo.setEnabled(True)
+        combo.currentIndexChanged.connect(self._get_change_viewer_func(index))
+
+    def _enable_all_viewer_combos(self, data):
         """
-        Setup the dropdown boxes that correspond to each of the left, middle, and right views.  The combo boxes
-        initially are set to have FLUX, Error, DQ but will be dynamic depending on the type of data available either
-        from being loaded in or by being processed.
+        Setup the dropdown boxes that correspond to each of the left, middle,
+        and right views.  The combo boxes initially are set to have FLUX,
+        Error, DQ but will be dynamic depending on the type of data available
+        either from being loaded in or by being processed.
 
         :return:
         """
-        self._viewer_combos = []
-        self._viewer_combo_helpers = []
-        for i in range(3):
-            combo = getattr(self.ui, 'viewer{0}_combo'.format(i+1))
-            connect_combo_selection(self, 'viewer{0}_attribute'.format(i+1), combo)
-            helper = ComponentIDComboHelper(self, 'viewer{0}_attribute'.format(i+1))
-            helper.set_multiple_data([data])
-            combo.setEnabled(True)
-            combo.currentIndexChanged.connect(self._get_change_viewer_func(i))
-            self._viewer_combos.append(combo)
-            self._viewer_combo_helpers.append(helper)
+        self._enable_viewer_combo(
+            data, 0, 'single_viewer_combo', 'single_viewer_attribute')
+
+        for i in range(1,4):
+            combo_label = 'viewer{0}_combo'.format(i)
+            selection_label = 'viewer{0}_attribute'.format(i)
+            self._enable_viewer_combo(data, i, combo_label, selection_label)
+
 
     def add_overlay(self, data, label):
         self._overlay_controller.add_overlay(data, label)
@@ -325,7 +332,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._enable_option_buttons()
         self._setup_syncing()
 
-        self._enable_viewer_combos(data)
+        self._enable_all_viewer_combos(data)
 
         self.subWindowActivated.emit(self._active_view)
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -374,6 +374,13 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Update the slice index to reflect the state of the active cube
         self._slice_controller.update_index(self._active_cube._widget.slice_index)
 
+        for viewer in self.cube_views:
+            viewer._widget.toolbar.setVisible(self._toolbars_visible)
+
+        if self._viewer_axes_positions:
+            self._hide_viewer_axes()
+
+
     def _activate_single_image_mode(self, event=None):
         vsplitter = self.ui.vertical_splitter
         hsplitter = self.ui.horizontal_splitter

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -117,22 +117,8 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Indicates whether cube viewer toolbars are currently visible or not
         self._toolbars_visible = True
 
-        # Leave these to reenable for the single image viewer if desired
-        #self.ui.toggle_flux.setStyleSheet('background-color: {0};'.format(COLOR[FLUX]))
-        #self.ui.toggle_error.setStyleSheet('background-color: {0};'.format(COLOR[ERROR]))
-        #self.ui.toggle_quality.setStyleSheet('background-color: {0};'.format(COLOR[MASK]))
-
-        #self.ui.toggle_flux.setChecked(True)
-        #self.ui.toggle_error.setChecked(False)
-        #self.ui.toggle_quality.setChecked(False)
-
-        #self.ui.toggle_flux.toggled.connect(self._toggle_flux)
-        #self.ui.toggle_error.toggled.connect(self._toggle_error)
-        #self.ui.toggle_quality.toggled.connect(self._toggle_quality)
-
         self._slice_controller = SliceController(self)
         self._overlay_controller = OverlayController(self)
-
 
         # Add menu buttons to the cubeviz toolbar.
         self._init_menu_buttons()
@@ -260,15 +246,6 @@ class CubeVizLayout(QtWidgets.QWidget):
             button.setEnabled(True)
         self.ui.sync_button.setEnabled(True)
 
-    def _toggle_flux(self, event=None):
-        self.single_view._widget.state.layers[0].visible = self.ui.toggle_flux.isChecked()
-
-    def _toggle_error(self, event=None):
-        self.single_view._widget.state.layers[1].visible = self.ui.toggle_error.isChecked()
-
-    def _toggle_quality(self, event=None):
-        self.single_view._widget.state.layers[2].visible = self.ui.toggle_quality.isChecked()
-
     def _get_change_viewer_func(self, view_index):
         def change_viewer(dropdown_index):
             view = self.views[view_index]
@@ -336,10 +313,6 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._enable_all_viewer_combos(data)
 
         self.subWindowActivated.emit(self._active_view)
-
-        #self._toggle_flux()
-        #self._toggle_error()
-        #self._toggle_quality()
 
     def eventFilter(self, obj, event):
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -147,7 +147,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._active_split_cube = None
 
         # Set the default to parallel image viewer
-        self._single_image = False
+        self._single_viewer_mode = False
         self.ui.button_toggle_image_mode.setText('Single Image Viewer')
         self.ui.viewer_control_frame.setCurrentIndex(0)
 
@@ -352,25 +352,29 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def _toggle_image_mode(self, event=None):
         # Currently in single image, moving to split image
-        if self._single_image:
+        if self._single_viewer_mode:
             self._active_cube = self._active_split_cube
-            self._split_image_mode(event)
-            self._single_image = False
+            self._activate_split_image_mode(event)
+            self._single_viewer_mode = False
             self.ui.button_toggle_image_mode.setText('Single Image Viewer')
             self.ui.viewer_control_frame.setCurrentIndex(0)
+            if self.single_view._widget.synced:
+                for view in self.split_views:
+                    if view._widget.synced:
+                        view._widget.update_slice_index(self.single_view._widget.slice_index)
         # Currently in split image, moving to single image
         else:
             self._active_split_cube = self._active_cube
             self._active_cube = self.single_view
-            self._single_image_mode(event)
-            self._single_image = True
+            self._activate_single_image_mode(event)
+            self._single_viewer_mode = True
             self.ui.button_toggle_image_mode.setText('Split Image Viewer')
             self.ui.viewer_control_frame.setCurrentIndex(1)
 
         # Update the slice index to reflect the state of the active cube
         self._slice_controller.update_index(self._active_cube._widget.slice_index)
 
-    def _single_image_mode(self, event=None):
+    def _activate_single_image_mode(self, event=None):
         vsplitter = self.ui.vertical_splitter
         hsplitter = self.ui.horizontal_splitter
         vsizes = list(vsplitter.sizes())
@@ -380,7 +384,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         vsplitter.setSizes(vsizes)
         hsplitter.setSizes(hsizes)
 
-    def _split_image_mode(self, event=None):
+    def _activate_split_image_mode(self, event=None):
         vsplitter = self.ui.vertical_splitter
         hsplitter = self.ui.horizontal_splitter
         vsizes = list(vsplitter.sizes())
@@ -419,12 +423,13 @@ class CubeVizLayout(QtWidgets.QWidget):
     def _on_sync_click(self, event=None):
         index = self._active_cube._widget.slice_index
         for view in self.cube_views:
-            view._widget.enable_button()
+            view._widget.set_sync_button()
             if view != self._active_cube:
                 view._widget.update_slice_index(index)
+        self._slice_controller.update_index(index)
 
     def showEvent(self, event):
         super(CubeVizLayout, self).showEvent(event)
         # Make split image mode the default layout
-        self._split_image_mode()
+        self._activate_split_image_mode()
         self._update_active_view(self.left_view)

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -73,114 +73,6 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1" alignment="Qt::AlignLeft">
-       <widget class="QGroupBox" name="groupBox_3">
-        <property name="font">
-         <font>
-          <pointsize>16</pointsize>
-         </font>
-        </property>
-        <property name="title">
-         <string/>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-             <underline>false</underline>
-            </font>
-           </property>
-           <property name="text">
-            <string>Viewer 1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_5">
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Viewer 2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="label_6">
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Viewer 3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QComboBox" name="viewer1_combo">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string>Select data to display in left hand viewer</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QComboBox" name="viewer2_combo">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string>Select data to display in middle viewer</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QComboBox" name="viewer3_combo">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string>Select data to display in right hand viewer</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
       <item row="2" column="6" alignment="Qt::AlignLeft">
        <widget class="QGroupBox" name="groupBox">
         <property name="font">
@@ -559,6 +451,143 @@
         <property name="arrowType">
          <enum>Qt::NoArrow</enum>
         </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QStackedWidget" name="viewer_control_frame">
+        <property name="font">
+         <font>
+          <pointsize>16</pointsize>
+         </font>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <widget class="QWidget" name="stackedWidget_3Page1" native="true">
+         <layout class="QGridLayout" name="gridLayout_3">
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+              <underline>false</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>Viewer 1</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_5">
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Viewer 2</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_6">
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Viewer 3</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QComboBox" name="viewer1_combo">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string>Select data to display in left hand viewer</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="viewer2_combo">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string>Select data to display in middle viewer</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QComboBox" name="viewer3_combo">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string>Select data to display in right hand viewer</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="page">
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="label_9">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Single Viewer</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="single_viewer_combo">
+            <property name="maximumSize">
+             <size>
+              <width>150</width>
+              <height>16777215</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
      </layout>

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1671</width>
+    <width>1676</width>
     <height>583</height>
    </rect>
   </property>
@@ -457,8 +457,14 @@
        <widget class="QStackedWidget" name="viewer_control_frame">
         <property name="font">
          <font>
-          <pointsize>16</pointsize>
+          <pointsize>13</pointsize>
          </font>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="currentIndex">
          <number>1</number>
@@ -472,118 +478,156 @@
            <number>6</number>
           </property>
           <item row="0" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-              <weight>75</weight>
-              <bold>true</bold>
-              <underline>false</underline>
-             </font>
+           <widget class="QGroupBox" name="groupBox_3">
+            <property name="title">
+             <string/>
             </property>
-            <property name="text">
-             <string>Viewer 1</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="label_5">
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Viewer 2</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_6">
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Viewer 3</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QComboBox" name="viewer1_combo">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>Select data to display in left hand viewer</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="viewer2_combo">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>Select data to display in middle viewer</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QComboBox" name="viewer3_combo">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>Select data to display in right hand viewer</string>
-            </property>
+            <layout class="QGridLayout" name="gridLayout_5">
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="1">
+              <widget class="QLabel" name="label_5">
+               <property name="font">
+                <font>
+                 <pointsize>13</pointsize>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Viewer 2</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLabel" name="label_6">
+               <property name="font">
+                <font>
+                 <pointsize>13</pointsize>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Viewer 3</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QComboBox" name="viewer1_combo">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>13</pointsize>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>Select data to display in left hand viewer</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QComboBox" name="viewer2_combo">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>13</pointsize>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>Select data to display in middle viewer</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QComboBox" name="viewer3_combo">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>13</pointsize>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>Select data to display in right hand viewer</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_4">
+               <property name="font">
+                <font>
+                 <pointsize>13</pointsize>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                 <underline>false</underline>
+                </font>
+               </property>
+               <property name="text">
+                <string>Viewer 1</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>
         </widget>
         <widget class="QWidget" name="page">
          <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QLabel" name="label_9">
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
+          <item alignment="Qt::AlignLeft">
+           <widget class="QGroupBox" name="groupBox_4">
+            <property name="title">
+             <string/>
             </property>
-            <property name="text">
-             <string>Single Viewer</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="single_viewer_combo">
-            <property name="maximumSize">
-             <size>
-              <width>150</width>
-              <height>16777215</height>
-             </size>
-            </property>
+            <layout class="QGridLayout" name="gridLayout_6">
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_9">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>Viewer Contents</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QComboBox" name="single_viewer_combo">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>150</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>13</pointsize>
+                </font>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -68,20 +68,16 @@ class CubevizManager(HubListener):
                          cubeviz_layout.middle_view._widget,
                          cubeviz_layout.right_view._widget]
 
+        # Single viewer should display FLUX only by default
+        image_viewers[0].add_data(data)
+        image_viewers[0].state.aspect = 'auto'
+        image_viewers[0].state.layers[0].attribute = data.id[FLUX]
+
+        # Split image viewers should each show different component by default
         for i, attribute in enumerate([FLUX, ERROR, MASK]):
-
-            image_viewers[0].add_data(data)
-            image_viewers[0].state.aspect = 'auto'
-            image_viewers[0].state.color_mode = 'One color per layer'
-            image_viewers[0].state.layers[i].attribute = data.id[attribute]
-
             image_viewers[1 + i].add_data(data)
             image_viewers[1 + i].state.aspect = 'auto'
             image_viewers[1 + i].state.layers[0].attribute = data.id[attribute]
-
-        image_viewers[0].state.layers[0].color = COLOR[FLUX]
-        image_viewers[0].state.layers[1].color = COLOR[ERROR]
-        image_viewers[0].state.layers[2].color = COLOR[MASK]
 
         cubeviz_layout.add_data(data)
 


### PR DESCRIPTION
This PR adds a few improvements to the user interface:
* it allows individual viewer toolbars to be hidden
* it allows the axes in the viewers to be hidden so the image can expand to fill the entire viewer
* it restores and updates the functionality of the single image viewer

Also, it integrates the changes that @astrofrog made in #125, so that PR can be closed.

**NOTE**: It is not yet ready for merge since I still need to work out some of the interface logic since we need to account for the interaction between the split image layout and the single image layout.