### PR TITLE
Fix focus problems with tool GUIs

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -736,7 +736,7 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         if event.type() == QtCore.QEvent.MouseButtonPress:
 
-            if not self.isVisible():
+            if not (self.isVisible() and self.isActiveWindow()):
                 return super(CubeVizLayout, self).eventFilter(obj, event)
 
             # Find global click position

--- a/cubeviz/tools/arithmetic_gui.py
+++ b/cubeviz/tools/arithmetic_gui.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import, division, print_function
 from qtpy.QtCore import Qt
 from qtpy import QtGui
 from qtpy.QtWidgets import (
-    QMainWindow, QApplication, QPushButton,
+    QDialog, QApplication, QPushButton,
     QLabel, QWidget, QHBoxLayout, QVBoxLayout, QLineEdit
 )
 
 # TODO: In the future, it might be nice to be able to work across data_collection elements
 
-class SelectArithmetic(QMainWindow):
+class SelectArithmetic(QDialog):
     def __init__(self, data, data_collection, parent=None):
         super(SelectArithmetic,self).__init__(parent)
 
@@ -121,9 +121,7 @@ class SelectArithmetic(QMainWindow):
         vbl.addLayout(hbl_examples)
         vbl.addLayout(hbl5)
 
-        self.wid = QWidget(self)
-        self.setCentralWidget(self.wid)
-        self.wid.setLayout(vbl)
+        self.setLayout(vbl)
         self.setMaximumWidth(700)
         self.show()
 

--- a/cubeviz/tools/moment_maps.py
+++ b/cubeviz/tools/moment_maps.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import, division, print_function
 from qtpy.QtCore import Qt
 from qtpy import QtGui
 from qtpy.QtWidgets import (
-    QMainWindow, QComboBox, QPushButton,
+    QDialog, QComboBox, QPushButton,
     QLabel, QWidget, QHBoxLayout, QVBoxLayout
 )
 
 
 # TODO: In the future, it might be nice to be able to work across data_collection elements
 
-class MomentMapsGUI(QMainWindow):
+class MomentMapsGUI(QDialog):
     def __init__(self, data, data_collection, parent=None):
         super(MomentMapsGUI, self).__init__(parent)
 
@@ -85,9 +85,7 @@ class MomentMapsGUI(QMainWindow):
         vbl.addLayout(hbl2)
         vbl.addLayout(hbl5)
 
-        self.wid = QWidget(self)
-        self.setCentralWidget(self.wid)
-        self.wid.setLayout(vbl)
+        self.setLayout(vbl)
         self.setMaximumWidth(700)
         self.show()
 

--- a/cubeviz/tools/smoothing.py
+++ b/cubeviz/tools/smoothing.py
@@ -12,8 +12,8 @@ from spectral_cube import SpectralCube, BooleanArrayMask
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
-    QMainWindow, QApplication, QPushButton,
-    QLabel, QWidget, QHBoxLayout, QVBoxLayout,
+    QDialog, QApplication, QPushButton,
+    QLabel, QWidget, QDockWidget, QHBoxLayout, QVBoxLayout,
     QComboBox, QMessageBox, QLineEdit, QRadioButton
 )
 
@@ -239,7 +239,7 @@ class Smooth(object):
         ex = SelectSmoothing(self.data, self.parent)
 
 
-class SelectSmoothing(QMainWindow):
+class SelectSmoothing(QDialog):
     """
     SelectSmoothing launches a GUI and executes smoothing.
     Any output is added to the input data as a new component.
@@ -353,11 +353,7 @@ class SelectSmoothing(QMainWindow):
         vbl.addLayout(hbl4)
         vbl.addLayout(hbl5)
 
-        # Add Vertical Layout to Central Widget
-        self.wid = QWidget(self)
-        self.setCentralWidget(self.wid)
-        self.wid.setLayout(vbl)
-
+        self.setLayout(vbl)
         self.setMaximumWidth(330)
 
         # Connect kernel combo box to event handler
@@ -389,11 +385,8 @@ class SelectSmoothing(QMainWindow):
         Displays while smoothing freezes the application.
         Allows abort button to be added if needed.
         """
-        self.abort_window = QMainWindow(
-            parent=self.parent,
-            flags=Qt.WindowStaysOnTopHint)
-        self.abort_window.setWindowFlags(
-            self.abort_window.windowFlags() | Qt.Tool)
+        self.abort_window = QDialog(parent=self.parent)
+        self.abort_window.setModal(False)
 
         label_a_1 = QLabel("Executing smoothing algorithm.")
         label_a_2 = QLabel("This may take several minutes.")
@@ -405,9 +398,7 @@ class SelectSmoothing(QMainWindow):
         vbl.addWidget(label_a_1)
         vbl.addWidget(label_a_2)
 
-        wid_abort = QWidget(self.abort_window)
-        self.abort_window.setCentralWidget(wid_abort)
-        wid_abort.setLayout(vbl)
+        self.abort_window.setLayout(wid_abort)
 
         self.abort_window.show()
 

--- a/cubeviz/tools/smoothing.py
+++ b/cubeviz/tools/smoothing.py
@@ -398,7 +398,7 @@ class SelectSmoothing(QDialog):
         vbl.addWidget(label_a_1)
         vbl.addWidget(label_a_2)
 
-        self.abort_window.setLayout(wid_abort)
+        self.abort_window.setLayout(vbl)
 
         self.abort_window.show()
 


### PR DESCRIPTION
This fixes #135. It should take care of the weird issues that occurred when trying to click on and/or enter text into the pop-up tool GUIs.

@robelgeda I had a hard time finding a solution for the abort dialog that provided a non-modal pop-up that also stays on top. For the time being I settled on using a non-modal dialog. The problem is that this dialog will disappear behind the main window if it loses focus. Maybe someone else knows of a better solution.