### PR TITLE
Refactoring of controllers into different modules

### DIFF
--- a/cubeviz/controls/overlay.py
+++ b/cubeviz/controls/overlay.py
@@ -1,0 +1,127 @@
+import numpy as np
+from glue.core.data import Data
+from glue.config import colormaps as glue_colormaps
+
+
+DEFAULT_GLUE_COLORMAP_INDEX = 3
+
+
+class OverlayController:
+
+    def __init__(self, cubeviz_layout):
+        self._cv_layout = cubeviz_layout
+        self._cubes = cubeviz_layout.cubes
+        ui = cubeviz_layout.ui
+
+        self._overlays = Data('Overlays')
+        # This is a list of overlay objects that are currently displayed
+        self._active_overlays = []
+        # Maps overlays to the data sets they represent
+        self._overlay_map = {}
+        self._overlay_colorbar_axis = []
+
+        self._overlay_image_combo = ui.overlay_image_combo
+        self._overlay_colormap_combo = ui.overlay_colormap_combo
+        self._alpha_slider = ui.alpha_slider
+        self._colormap_index = DEFAULT_GLUE_COLORMAP_INDEX
+
+        self._overlay_image_combo.addItem("No Overlay")
+        self._overlay_image_combo.currentIndexChanged.connect(
+            self._on_overlay_change)
+
+        self._overlay_colormap_combo.setCurrentIndex(self._colormap_index)
+        self._overlay_colormap_combo.currentIndexChanged.connect(
+            self._on_colormap_change)
+
+        self._alpha_slider.valueChanged.connect(self._on_alpha_change)
+
+    def add_overlay(self, data, label):
+        self._overlays.add_component(data, label)
+        # TODO: Is there a way to get this from the component ???
+        self._overlay_image_combo.addItem(label)
+        new_index = self._overlay_image_combo.count() - 1
+        self._overlay_map[new_index] = data
+
+        self._alpha_slider.setEnabled(True)
+        self._overlay_image_combo.setEnabled(True)
+        self._overlay_colormap_combo.setEnabled(True)
+
+        # Setting the index will cause _on_overlay_change to fire
+        self._overlay_image_combo.setCurrentIndex(new_index)
+
+    def _on_overlay_change(self, index):
+        if index == 0:
+            data = None
+        else:
+            data = self._overlay_map[index]
+        self.display_overlay(data)
+
+    def _on_colormap_change(self, index):
+        self._colormap_index = index
+        colormap = glue_colormaps.members[self._colormap_index][1]
+        for overlay in self._active_overlays:
+            overlay.set_cmap(colormap)
+        for cb in self._overlay_colorbar_axis:
+            for cbim in cb.get_images():
+                cbim.set_cmap(colormap)
+        for cube in self._cubes:
+            cube._widget.figure.canvas.draw()
+
+    def _draw_mpl_overlay(self, data, view):
+        axes = view._widget.axes
+        aspect = axes.get_aspect()
+
+        extent = 0, data.shape[0], 0, data.shape[1]
+
+        colormap = glue_colormaps.members[self._colormap_index][1]
+        overlay = view._widget.axes.imshow(
+            data, origin='lower', cmap=colormap, alpha=.25,
+            interpolation='none', aspect=aspect, extent=extent)
+
+        self._active_overlays.append(overlay)
+
+        # Add the overlay colorbar as an axis
+        oca = view._widget.figure.add_axes([0.02, 0.04, 0.3, 0.025], projection='rectilinear')
+        mindata, maxdata = np.nanmin(data), np.nanmax(data)
+        oca_image = np.zeros((1,100))
+        oca_image[0] = np.arange(mindata, maxdata, (maxdata-mindata)/100)
+        oca.imshow(oca_image, origin='lower', cmap=colormap, aspect=aspect, extent=[0,100,0,100])
+        oca.set_xticks([0, 25, 50, 75, 100])
+        oca.set_xticklabels(['%3.2e'%x for x in np.arange(mindata, maxdata, (maxdata-mindata)/5)], fontsize=6)
+        oca.set_yticks([])
+        self._overlay_colorbar_axis.append(oca)
+
+        view._widget.figure.canvas.draw()
+
+    def display_overlay(self, data):
+        # Remove all existing overlays
+        if self._active_overlays:
+            for overlay, view, cb in zip(
+                    self._active_overlays, self._cubes, self._overlay_colorbar_axis):
+                overlay.remove()
+                cb.remove()
+                view._widget.figure.canvas.draw()
+
+            self._active_overlays = []
+            self._overlay_colorbar_axis = []
+
+        # Just return if no new overlay is to be drawn
+        if data is None:
+            return
+
+        self._active_overlays = []
+        for view in self._cubes:
+            self._draw_mpl_overlay(data, view)
+
+        self._alpha_slider.setValue(25)
+
+    def _on_alpha_change(self, event):
+        """
+        Callback for change in alpha value.
+
+        :param event:
+        :return:
+        """
+        for overlay in self._active_overlays:
+            overlay.set_alpha(self._alpha_slider.value() / 100.)
+            overlay.figure.canvas.draw()

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -1,0 +1,167 @@
+import numpy as np
+from specviz.third_party.glue.data_viewer import dispatch as specviz_dispatch
+
+
+class SliceController:
+
+    def __init__(self, cubeviz_layout):
+        self._cv_layout = cubeviz_layout
+        ui = cubeviz_layout.ui
+
+        # These are the contents of the text boxes
+        self._slice_textbox = ui.text_slice
+        self._wavelength_textbox = ui.text_wavelength
+
+        # This is the slider widget itself
+        self._slice_slider = ui.value_slice
+
+        # This is the label for the wavelength units
+        self._wavelength_textbox_label = ui.wavelength_slider_text
+
+        self._slice_slider.valueChanged.connect(self._on_slider_change)
+        self._slice_textbox.returnPressed.connect(self._on_text_slice_change)
+        self._wavelength_textbox.returnPressed.connect(self._on_text_wavelength_change)
+
+        self._slice_slider.setEnabled(False)
+        self._slice_textbox.setEnabled(False)
+        self._wavelength_textbox.setEnabled(False)
+
+        self._wavelength_format = '{}'
+        self._wavelength_units = None
+        self._wavelengths = None
+
+        # Connect this class to specviz's event dispatch so methods can listen
+        # to specviz events
+        specviz_dispatch.setup(self)
+
+
+    def enable(self, wcs, wavelengths):
+        """
+        Setup the slice slider (min/max, units on description and initial position). 
+
+        :return:
+        """
+        self._slice_slider.setEnabled(True)
+        self._slice_textbox.setEnabled(True)
+        self._wavelength_textbox.setEnabled(True)
+
+        self._slice_slider.setMinimum(0)
+
+        # Store the wavelength units and format
+        self._wavelength_units = str(wcs.wcs.cunit[2])
+        self._wavelength_format = '{:.3}'
+        self._wavelength_textbox_label.setText('Wavelength ({})'.format(self._wavelength_units))
+
+        # Grab the wavelengths so they can be displayed in the text box
+        self._wavelengths = wavelengths
+        self._slice_slider.setMaximum(len(self._wavelengths) - 1)
+
+        # Set the default display to the middle of the cube
+        middle_index = len(self._wavelengths) // 2
+        self._update_slice_textboxes(middle_index)
+        self._slice_slider.setValue(middle_index)
+        self._wavelength_textbox.setText(self._wavelength_format.format(self._wavelengths[middle_index]))
+
+
+    def update_index(self, index):
+        self._slice_slider.setValue(index)
+        self._update_slice_textboxes(index)
+
+
+    def _on_slider_change(self, event):
+        """
+        Callback for change in slider value.
+
+        :param event:
+        :return:
+        """
+        index = self._slice_slider.value()
+        all_cubes = self._cv_layout.cubes
+        active_cube = self._cv_layout._active_cube
+        active_widget = active_cube._widget
+
+        # Update the image displayed in the slice in the active view
+        active_widget.update_slice_index(index)
+
+        # If the active widget is synced then we need to update the image
+        # in all the other synced views.
+        if active_widget.synced:
+            for cube in all_cubes:
+                if cube != active_cube and cube._widget.synced:
+                    cube._widget.update_slice_index(index)
+
+        # Now update the slice and wavelength text boxes
+        self._update_slice_textboxes(index)
+
+        specviz_dispatch.changed_dispersion_position.emit(pos=index)
+
+
+    def _update_slice_textboxes(self, index):
+        """
+        Update the slice index number text box and the wavelength value displayed in the wavelengths text box.
+
+        :param index: Slice index number displayed.
+        :return:
+        """
+
+        # Update the input text box for slice number
+        self._slice_textbox.setText(str(index))
+
+        # Update the wavelength for the corresponding slice number.
+        self._wavelength_textbox.setText(self._wavelength_format.format(self._wavelengths[index]))
+
+
+    def _on_text_slice_change(self, event=None):
+        """
+        Callback for a change in the slice index text box.  We will need to
+        update the slider and the wavelength value when this changes.
+
+        :param event:
+        :return:
+        """
+
+        # Get the value they typed in, but if not a number, then let's just use
+        # the first slice.
+        try:
+            index = int(self._slice_textbox.text())
+        except ValueError:
+            # If invalid value is given, revert to current value
+            index = self._cubeviz_layout.single_view._widget.state.slices[0]
+
+        # If a number and out of range then set to the first or last slice
+        # depending if they set the number too low or too high.
+        if index < 0:
+            index = 0
+        if index > len(self._wavelengths) - 1:
+            index = len(self._wavelengths) - 1
+
+        # Now update the slice and wavelength text boxes
+        self._update_slice_textboxes(index)
+
+        # Update the slider.
+        self._slice_slider.setValue(index)
+
+
+    @specviz_dispatch.register_listener("change_dispersion_position")
+    def _on_text_wavelength_change(self, event=None):
+        """
+        Callback for a change in wavelength inptu box. We want to find the
+        closest wavelength and use the index of it.  We will need to update the slice index box and slider as
+        well as the image.
+
+        :param event:
+        :return:
+        """
+        try:
+            # Find the closest real wavelength and use the index of it
+            wavelength = float(self._wavelength_textbox.text())
+            index = np.argsort(abs(self._wavelengths - wavelength))[0]
+        except ValueError:
+            # If invalid value is given, revert to current value
+            index = self._cubeviz_layout.single_view._widget.state.slices[0]
+
+        # Now update the slice and wavelength text boxes
+        self._update_slice_textboxes(index)
+
+        # Update the slider.
+        self._slice_slider.setValue(index)

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -143,18 +143,23 @@ class SliceController:
 
 
     @specviz_dispatch.register_listener("change_dispersion_position")
-    def _on_text_wavelength_change(self, event=None):
+    def _on_text_wavelength_change(self, event=None, pos=None):
         """
-        Callback for a change in wavelength inptu box. We want to find the
-        closest wavelength and use the index of it.  We will need to update the slice index box and slider as
-        well as the image.
+        Callback for a change in wavelength input box. We want to find the
+        closest wavelength and use the index of it.  We will need to update the
+        slice index box and slider as well as the image.
 
         :param event:
+        :param pos: This is the argument used by the specviz event listener to
+                    update the CubeViz slider and associated text based on the
+                    movement of the SpecViz position bar. The name of this
+                    argument cannot change since it is the one expected by the
+                    SpecViz event system.
         :return:
         """
         try:
             # Find the closest real wavelength and use the index of it
-            wavelength = float(self._wavelength_textbox.text())
+            wavelength = pos if pos is not None else float(self._wavelength_textbox.text())
             index = np.argsort(abs(self._wavelengths - wavelength))[0]
         except ValueError:
             # If invalid value is given, revert to current value

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -1,6 +1,7 @@
 import numpy as np
 from specviz.third_party.glue.data_viewer import dispatch as specviz_dispatch
 
+RED_BACKGROUND = "background-color: rgba(255, 0, 0, 128);"
 
 class SliceController:
 
@@ -124,9 +125,10 @@ class SliceController:
         # the first slice.
         try:
             index = int(self._slice_textbox.text())
+            self._slice_textbox.setStyleSheet("")
         except ValueError:
-            # If invalid value is given, revert to current value
-            index = self._cubeviz_layout.single_view._widget.state.slices[0]
+            self._slice_textbox.setStyleSheet(RED_BACKGROUND)
+            return
 
         # If a number and out of range then set to the first or last slice
         # depending if they set the number too low or too high.
@@ -161,9 +163,10 @@ class SliceController:
             # Find the closest real wavelength and use the index of it
             wavelength = pos if pos is not None else float(self._wavelength_textbox.text())
             index = np.argsort(abs(self._wavelengths - wavelength))[0]
+            self._wavelength_textbox.setStyleSheet("")
         except ValueError:
-            # If invalid value is given, revert to current value
-            index = self._cubeviz_layout.single_view._widget.state.slices[0]
+            self._wavelength_textbox.setStyleSheet(RED_BACKGROUND)
+            return
 
         # Now update the slice and wavelength text boxes
         self._update_slice_textboxes(index)

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -9,14 +9,14 @@ class SliceController:
         ui = cubeviz_layout.ui
 
         # These are the contents of the text boxes
-        self._slice_textbox = ui.text_slice
-        self._wavelength_textbox = ui.text_wavelength
+        self._slice_textbox = ui.slice_textbox
+        self._wavelength_textbox = ui.wavelength_textbox
 
         # This is the slider widget itself
-        self._slice_slider = ui.value_slice
+        self._slice_slider = ui.slice_slider
 
         # This is the label for the wavelength units
-        self._wavelength_textbox_label = ui.wavelength_slider_text
+        self._wavelength_textbox_label = ui.wavelength_textbox_label
 
         self._slice_slider.valueChanged.connect(self._on_slider_change)
         self._slice_textbox.returnPressed.connect(self._on_text_slice_change)

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -63,6 +63,7 @@ class SliceController:
         self._slice_slider.setValue(middle_index)
         self._wavelength_textbox.setText(self._wavelength_format.format(self._wavelengths[middle_index]))
 
+        self._cv_layout.synced_index = middle_index
 
     def update_index(self, index):
         self._slice_slider.setValue(index)
@@ -90,6 +91,7 @@ class SliceController:
             for cube in all_cubes:
                 if cube != active_cube and cube._widget.synced:
                     cube._widget.update_slice_index(index)
+            self._cv_layout.synced_index = index
 
         # Now update the slice and wavelength text boxes
         self._update_slice_textboxes(index)

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -1,0 +1,256 @@
+# This file contains a sub-class of the glue image viewer with further
+# customizations.
+
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+
+from qtpy.QtWidgets import QLabel
+
+from glue.config import viewer_tool
+from glue.core.message import SettingsChangeMessage
+from glue.viewers.common.qt.tool import CheckableTool
+from glue.viewers.image.qt import ImageViewer
+
+
+__all__ = ['CubevizImageViewer']
+
+
+@viewer_tool
+class SyncButtonBox(CheckableTool):
+    """
+    SyncButtonBox derived from the Glue CheckableTool that will be placed on the
+    Matplotlib toolbar in order to allow syncing between the different views in
+    cubeviz.
+
+    We need to store the "synced" state of this button so that we can check it
+    in other parts of the code.
+    """
+
+    icon = 'glue_link'
+    tool_id = 'sync_checkbox'
+    action_text = 'Sync this viewer with other viewers'
+    tool_tip = 'Sync this viewer with other viewers'
+    status_tip = 'This viewer is synced'
+    shortcut = 'D'
+
+    def __init__(self, viewer):
+        super(SyncButtonBox, self).__init__(viewer)
+        self._viewer = viewer
+        self._synced = True
+        self._hub = None
+
+    def activate(self):
+        self._synced = True
+        if self._hub is not None:
+            msg = SettingsChangeMessage(self, [self._viewer])
+            self._hub.broadcast(msg)
+
+    def deactivate(self):
+        self._synced = False
+
+    def close(self):
+        pass
+
+
+class CubevizImageViewer(ImageViewer):
+
+    # Add the sync button to the front of the list so it is more prominent
+    # on smaller screens.
+    tools = ['sync_checkbox', 'select:rectangle', 'select:xrange',
+             'select:yrange', 'select:circle',
+             'select:polygon', 'image:contrast_bias']
+
+    def __init__(self, *args, **kwargs):
+        super(CubevizImageViewer, self).__init__(*args, **kwargs)
+        self._sync_button = None
+        self._slice_index = None
+
+        self.is_mouse_over = False  # If mouse cursor is over viewer
+        self.hold_coords = False  # Switch to hold current displayed coords
+        self._coords_in_degrees = True  # Switch display coords to True=deg or False=Deg/Hr:Min:Sec
+        self._coords_format_function = self._format_to_degree_string  # Function to format ra and dec
+        self.x_mouse = None  # x position of mouse in pix
+        self.y_mouse = None  # y position of mouse in pix
+
+        self.coord_label = QLabel("")  # Coord display
+        self.statusBar().addPermanentWidget(self.coord_label)
+
+        # Connect matplotlib events to event handlers
+        self.figure.canvas.mpl_connect('motion_notify_event', self.mouse_move)
+        self.figure.canvas.mpl_connect('axes_leave_event', self.mouse_exited)
+
+    def enable_toolbar(self):
+        self._sync_button = self.toolbar.tools[SyncButtonBox.tool_id]
+        self._sync_button._hub = self.parent().tab_widget.session.hub
+        self.enable_button()
+
+    def enable_button(self):
+        button = self.toolbar.actions[SyncButtonBox.tool_id]
+        button.setChecked(True)
+
+    def update_slice_index(self, index):
+        self._slice_index = index
+        z, y, x = self.state.slices
+        self.state.slices = (self._slice_index, y, x)
+
+    @property
+    def synced(self):
+        return self._sync_button._synced
+
+    @property
+    def slice_index(self):
+        return self._slice_index
+
+    def get_coords(self):
+        """
+        Returns coord display string.
+        """
+        if not self.is_mouse_over:
+            return None
+        return self.coord_label.text()
+
+    def toggle_hold_coords(self):
+        """
+        Switch hold_coords state
+        """
+        if self.hold_coords:
+            self.hold_coords = False
+        else:
+            self.statusBar().showMessage("Frozen Coordinates")
+            self.hold_coords = True
+
+    def toggle_coords_in_degrees(self):
+        """
+        Switch coords_in_degrees state
+        """
+        if self._coords_in_degrees:
+            self._coords_in_degrees = False
+            self._coords_format_function = self._format_to_hex_string
+        else:
+            self._coords_in_degrees = True
+            self._coords_format_function = self._format_to_degree_string
+
+    def clear_coords(self):
+        """
+        Reset coord display and mouse tracking variables.
+        If hold_coords is active (True), make changes
+        only to indicate that the mouse is no longer over viewer.
+        """
+        self.is_mouse_over = False
+        if self.hold_coords:
+            return
+        self.x_mouse = None
+        self.y_mouse = None
+        self.coord_label.setText('')
+
+    def _format_to_degree_string(self, ra, dec):
+        """
+        Format RA and Dec in degree format. If wavelength
+        is available add it to the output sting.
+        :return: string
+        """
+        coord_string = "({:0>8.4f}, {:0>8.4f}".format(ra, dec)
+
+        # Check if wavelength is available
+        if self.slice_index is not None and self.parent().tab_widget._wavelengths is not None:
+            wave = self.parent().tab_widget._wavelengths[self.slice_index]
+            coord_string += ", {:1.2e}m)".format(wave)
+        else:
+            coord_string += ")"
+
+        return coord_string
+
+    def _format_to_hex_string(self, ra, dec):
+        """
+        Format RA and Dec in D:M:S and H:M:S formats respectively. If wavelength
+        is available add it to the output sting.
+        :return: string
+        """
+        c = SkyCoord(ra=ra * u.degree, dec=dec * u.degree)
+        coord_string = "("
+        coord_string += "{0:0>2.0f}h:{1:0>2.0f}m:{2:0>2.0f}s".format(*c.ra.hms)
+        coord_string += "  "
+        coord_string += "{0:0>3.0f}d:{1:0>2.0f}m:{2:0>2.0f}s".format(*c.dec.dms)
+
+        # Check if wavelength is available
+        if self.slice_index is not None and self.parent().tab_widget._wavelengths is not None:
+            wave = self.parent().tab_widget._wavelengths[self.slice_index]
+            coord_string += "  {:1.2e}m)".format(wave)
+        else:
+            coord_string += ")"
+
+        return coord_string
+
+    def mouse_move(self, event):
+        """
+        Event handler for matplotlib motion_notify_event.
+        Updates coord display and vars.
+        :param event: matplotlib event.
+        """
+        # Check if mouse is in widget but not on plot
+        if not event.inaxes:
+            self.clear_coords()
+            return
+        self.is_mouse_over = True
+
+        # If hold_coords is active, return
+        if self.hold_coords:
+            return
+
+        # Get x and y of the pixel under the mouse
+        x, y = [int(event.xdata + 0.5), int(event.ydata + 0.5)]
+        self.x_mouse, self.y_mouse = [x, y]
+
+        # Create coord display string
+        if self._slice_index is not None:
+            string = "({:1.0f}, {:1.0f}, {:1.0f})".format(x, y, self._slice_index)
+        else:
+            string = "({:1.0f}, {:1.0f})".format(x, y)
+
+        # If viewer has a layer.
+        if len(self.state.layers) > 0:
+            # Get array arr that contains the image values
+            # Default layer is layer at index 0.
+            arr = self.state.layers[0].get_sliced_data()
+            if 0 <= y < arr.shape[0] and 0 <= x < arr.shape[1]:
+                # if x and y are in bounds. Note: x and y are swapped in array.
+                # get value and check if wcs is obtainable
+                # WCS:
+                if len(self.figure.axes) > 0:
+                    wcs = self.figure.axes[0].wcs.celestial
+                    if wcs is not None:
+                        # Check the number of axes in the WCS and add to string
+                        ra = dec = None
+                        if wcs.naxis == 3 and self.slice_index is not None:
+                            ra, dec, wave = wcs.wcs_pix2world([[x, y, self._slice_index]], 0)[0]
+                        elif wcs.naxis == 2:
+                            ra, dec = wcs.wcs_pix2world([[x, y]], 0)[0]
+
+                        if ra is not None and dec is not None:
+                            string = string + " " + self._coords_format_function(ra, dec)
+                # Pixel Value:
+                v = arr[y][x]
+                string = "{:1.4f} ".format(v) + string
+        # Add a gap to string and add to viewer.
+        string += " "
+        self.coord_label.setText(string)
+        return
+
+    def mouse_exited(self, event):
+        """
+        Event handler for matplotlib axes_leave_event.
+        Clears coord display and vars.
+        :param event: matplotlib event
+        """
+        self.clear_coords()
+        return
+
+    def leaveEvent(self, event):
+        """
+        Event handler for Qt widget leave events.
+        Clears coord display and vars.
+        Overrides default.
+        :param event: QEvent
+        """
+        self.clear_coords()
+        return

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -367,6 +367,9 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._component_labels = DEFAULT_DATA_LABELS.copy()
 
         self.sync = {}
+        # Track the slice index of the synced viewers. This is updated by the
+        # slice controller
+        self.synced_index = None
 
         app = get_qapp()
         app.installEventFilter(self)
@@ -427,7 +430,8 @@ class CubeVizLayout(QtWidgets.QWidget):
         return menu_widget
 
     def _handle_settings_change(self, message):
-        print(message)
+        if isinstance(message, SettingsChangeMessage):
+            self._slice_controller.update_index(self.synced_index)
 
     def _open_dialog(self, name, widget):
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -1,24 +1,20 @@
-from __future__ import print_function, division
-
 import os
 from collections import OrderedDict
 
 import numpy as np
 
-from astropy import units as u
-from astropy.coordinates import SkyCoord
-from glue.core import Hub
-from glue.core.message import SettingsChangeMessage
-from glue.config import qt_fixed_layout_tab, viewer_tool
-from glue.viewers.common.qt.tool import CheckableTool
 from qtpy import QtWidgets, QtCore
-from qtpy.QtWidgets import QMenu, QAction, QLabel
-from glue.viewers.image.qt import ImageViewer
-from specviz.third_party.glue.data_viewer import SpecVizViewer
-from glue.utils.qt import load_ui, get_text
-from glue.external.echo import keep_in_sync
-from glue.utils.qt import get_qapp
+from qtpy.QtWidgets import QMenu, QAction
 
+from glue.utils.qt import load_ui
+from glue.utils.qt import get_qapp
+from glue.config import qt_fixed_layout_tab
+from glue.external.echo import keep_in_sync
+from glue.core.message import SettingsChangeMessage
+
+from specviz.third_party.glue.data_viewer import SpecVizViewer
+
+from .image_viewer import CubevizImageViewer
 
 from .controls.slice import SliceController
 from .controls.overlay import OverlayController
@@ -33,245 +29,6 @@ COLOR = {}
 COLOR[FLUX] = '#888888'
 COLOR[ERROR] = '#ffaa66'
 COLOR[MASK] = '#66aaff'
-
-
-@viewer_tool
-class SyncButtonBox(CheckableTool):
-    """
-    SyncButtonBox derived from the Glue CheckableTool that will be placed on the Matplotlib toolbar
-    in order to allow syncing between the different views in cubeviz.
-
-    We need to store the "synced" state of this button so that we can check it in other parts of the code.
-    """
-
-    icon = 'glue_link'
-    tool_id = 'sync_checkbox'
-    action_text = 'Sync this viewer with other viewers'
-    tool_tip = 'Sync this viewer with other viewers'
-    status_tip = 'This viewer is synced'
-    shortcut = 'D'
-
-    def __init__(self, viewer):
-        super(SyncButtonBox, self).__init__(viewer)
-        self._viewer = viewer
-        self._synced = True
-        self._hub = None
-
-    def activate(self):
-        self._synced = True
-        if self._hub is not None:
-            msg = SettingsChangeMessage(self, [self._viewer])
-            self._hub.broadcast(msg)
-
-    def deactivate(self):
-        self._synced = False
-
-    def close(self):
-        pass
-
-
-class CubevizImageViewer(ImageViewer):
-
-    # Add the sync button to the front of the list so it is more prominent
-    # on smaller screens.
-    tools = ['sync_checkbox', 'select:rectangle', 'select:xrange',
-             'select:yrange', 'select:circle',
-             'select:polygon', 'image:contrast_bias']
-
-    def __init__(self, *args, **kwargs):
-        super(CubevizImageViewer, self).__init__(*args, **kwargs)
-        self._sync_button = None
-        self._slice_index = None
-
-        self.is_mouse_over = False  # If mouse cursor is over viewer
-        self.hold_coords = False  # Switch to hold current displayed coords
-        self._coords_in_degrees = True  # Switch display coords to True=deg or False=Deg/Hr:Min:Sec
-        self._coords_format_function = self._format_to_degree_string  # Function to format ra and dec
-        self.x_mouse = None  # x position of mouse in pix
-        self.y_mouse = None  # y position of mouse in pix
-
-        self.coord_label = QLabel("")  # Coord display
-        self.statusBar().addPermanentWidget(self.coord_label)
-
-        # Connect matplotlib events to event handlers
-        self.figure.canvas.mpl_connect('motion_notify_event', self.mouse_move)
-        self.figure.canvas.mpl_connect('axes_leave_event', self.mouse_exited)
-
-    def enable_toolbar(self):
-        self._sync_button = self.toolbar.tools[SyncButtonBox.tool_id]
-        self._sync_button._hub = self.parent().tab_widget.session.hub
-        self.enable_button()
-
-    def enable_button(self):
-        button = self.toolbar.actions[SyncButtonBox.tool_id]
-        button.setChecked(True)
-
-    def update_slice_index(self, index):
-        self._slice_index = index
-        z, y, x = self.state.slices
-        self.state.slices = (self._slice_index, y, x)
-
-    @property
-    def synced(self):
-        return self._sync_button._synced
-
-    @property
-    def slice_index(self):
-        return self._slice_index
-
-    def get_coords(self):
-        """
-        Returns coord display string.
-        """
-        if not self.is_mouse_over:
-            return None
-        return self.coord_label.text()
-
-    def toggle_hold_coords(self):
-        """
-        Switch hold_coords state
-        """
-        if self.hold_coords:
-            self.hold_coords = False
-        else:
-            self.statusBar().showMessage("Frozen Coordinates")
-            self.hold_coords = True
-
-    def toggle_coords_in_degrees(self):
-        """
-        Switch coords_in_degrees state
-        """
-        if self._coords_in_degrees:
-            self._coords_in_degrees = False
-            self._coords_format_function = self._format_to_hex_string
-        else:
-            self._coords_in_degrees = True
-            self._coords_format_function = self._format_to_degree_string
-
-    def clear_coords(self):
-        """
-        Reset coord display and mouse tracking variables.
-        If hold_coords is active (True), make changes
-        only to indicate that the mouse is no longer over viewer.
-        """
-        self.is_mouse_over = False
-        if self.hold_coords:
-            return
-        self.x_mouse = None
-        self.y_mouse = None
-        self.coord_label.setText('')
-
-    def _format_to_degree_string(self, ra, dec):
-        """
-        Format RA and Dec in degree format. If wavelength
-        is available add it to the output sting.
-        :return: string
-        """
-        coord_string = "({:0>8.4f}, {:0>8.4f}".format(ra, dec)
-
-        # Check if wavelength is available
-        if self.slice_index is not None and self.parent().tab_widget._wavelengths is not None:
-            wave = self.parent().tab_widget._wavelengths[self.slice_index]
-            coord_string += ", {:1.2e}m)".format(wave)
-        else:
-            coord_string += ")"
-
-        return coord_string
-
-    def _format_to_hex_string(self, ra, dec):
-        """
-        Format RA and Dec in D:M:S and H:M:S formats respectively. If wavelength
-        is available add it to the output sting.
-        :return: string
-        """
-        c = SkyCoord(ra=ra * u.degree, dec=dec * u.degree)
-        coord_string = "("
-        coord_string += "{0:0>2.0f}h:{1:0>2.0f}m:{2:0>2.0f}s".format(*c.ra.hms)
-        coord_string += "  "
-        coord_string += "{0:0>3.0f}d:{1:0>2.0f}m:{2:0>2.0f}s".format(*c.dec.dms)
-
-        # Check if wavelength is available
-        if self.slice_index is not None and self.parent().tab_widget._wavelengths is not None:
-            wave = self.parent().tab_widget._wavelengths[self.slice_index]
-            coord_string += "  {:1.2e}m)".format(wave)
-        else:
-            coord_string += ")"
-
-        return coord_string
-
-    def mouse_move(self, event):
-        """
-        Event handler for matplotlib motion_notify_event.
-        Updates coord display and vars.
-        :param event: matplotlib event.
-        """
-        # Check if mouse is in widget but not on plot
-        if not event.inaxes:
-            self.clear_coords()
-            return
-        self.is_mouse_over = True
-
-        # If hold_coords is active, return
-        if self.hold_coords:
-            return
-
-        # Get x and y of the pixel under the mouse
-        x, y = [int(event.xdata + 0.5), int(event.ydata + 0.5)]
-        self.x_mouse, self.y_mouse = [x, y]
-
-        # Create coord display string
-        if self._slice_index is not None:
-            string = "({:1.0f}, {:1.0f}, {:1.0f})".format(x, y, self._slice_index)
-        else:
-            string = "({:1.0f}, {:1.0f})".format(x, y)
-
-        # If viewer has a layer.
-        if len(self.state.layers) > 0:
-            # Get array arr that contains the image values
-            # Default layer is layer at index 0.
-            arr = self.state.layers[0].get_sliced_data()
-            if 0 <= y < arr.shape[0] and 0 <= x < arr.shape[1]:
-                # if x and y are in bounds. Note: x and y are swapped in array.
-                # get value and check if wcs is obtainable
-                # WCS:
-                if len(self.figure.axes) > 0:
-                    wcs = self.figure.axes[0].wcs.celestial
-                    if wcs is not None:
-                        # Check the number of axes in the WCS and add to string
-                        ra = dec = None
-                        if wcs.naxis == 3 and self.slice_index is not None:
-                            ra, dec, wave = wcs.wcs_pix2world([[x, y, self._slice_index]], 0)[0]
-                        elif wcs.naxis == 2:
-                            ra, dec = wcs.wcs_pix2world([[x, y]], 0)[0]
-
-                        if ra is not None and dec is not None:
-                            string = string + " " + self._coords_format_function(ra, dec)
-                # Pixel Value:
-                v = arr[y][x]
-                string = "{:1.4f} ".format(v) + string
-        # Add a gap to string and add to viewer.
-        string += " "
-        self.coord_label.setText(string)
-        return
-
-    def mouse_exited(self, event):
-        """
-        Event handler for matplotlib axes_leave_event.
-        Clears coord display and vars.
-        :param event: matplotlib event
-        """
-        self.clear_coords()
-        return
-
-    def leaveEvent(self, event):
-        """
-        Event handler for Qt widget leave events.
-        Clears coord display and vars.
-        Overrides default.
-        :param event: QEvent
-        """
-        self.clear_coords()
-        return
 
 
 class WidgetWrapper(QtWidgets.QWidget):
@@ -440,7 +197,6 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         if name == 'Arithmetic Operations':
             ex = arithmetic_gui.SelectArithmetic(self._data, self.session.data_collection, parent=self)
-
 
         if name == "Moment Maps":
             moment_maps.MomentMapsGUI(

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -385,7 +385,7 @@
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="QLabel" name="wavelength_slider_text">
+          <widget class="QLabel" name="wavelength_textbox_label">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -407,7 +407,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QSlider" name="value_slice">
+          <widget class="QSlider" name="slice_slider">
            <property name="minimumSize">
             <size>
              <width>0</width>
@@ -429,7 +429,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QLineEdit" name="text_slice">
+          <widget class="QLineEdit" name="slice_textbox">
            <property name="maximumSize">
             <size>
              <width>50</width>
@@ -450,7 +450,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QLineEdit" name="text_wavelength">
+          <widget class="QLineEdit" name="wavelength_textbox">
            <property name="maximumSize">
             <size>
              <width>200</width>

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from glue.core import Hub, HubListener, Data, DataCollection
-from glue.core.message import DataCollectionAddMessage, DataAddComponentMessage
+from glue.core.message import (DataCollectionAddMessage,
+                               DataAddComponentMessage, SettingsChangeMessage)
 from .layout import CubeVizLayout, COLOR, FLUX, ERROR, MASK
 
 
@@ -24,6 +25,8 @@ class CubevizManager(HubListener):
             self, DataCollectionAddMessage, handler=self.handle_new_dataset)
         self._hub.subscribe(
             self, DataAddComponentMessage, handler=self.handle_new_component)
+        self._hub.subscribe(
+            self, SettingsChangeMessage, handler=self.handle_settings_change)
 
         # Look for any cube data files that were loaded from the command line
         for data in session.data_collection:
@@ -50,6 +53,9 @@ class CubevizManager(HubListener):
     def handle_new_component(self, message):
         #self._layout.add_new_data_component(str(message.component_id))
         self._layout.add_new_data_component(message.component_id)
+
+    def handle_settings_change(self, message):
+        self._layout._handle_settings_change(message)
 
     def hide_sidebar(self):
         self._app._ui.main_splitter.setSizes([0, 300])

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -55,7 +55,8 @@ class CubevizManager(HubListener):
         self._layout.add_new_data_component(message.component_id)
 
     def handle_settings_change(self, message):
-        self._layout._handle_settings_change(message)
+        if self._layout is not None:
+            self._layout._handle_settings_change(message)
 
     def hide_sidebar(self):
         self._app._ui.main_splitter.setSizes([0, 300])


### PR DESCRIPTION
@brechmos-stsci and I have refactored the control logic for slice navigation and moment map overlays into separate modules, which makes `layout.py` substantially easier to manage. It also incorporates @astrofrog's refactoring of the `CubevizImageViewer` into a separate module (from PR #121). Along with all of this are variable renames and other general code cleanup.

Also this fixes the behavior of the viewer toolbar sync buttons, which was previously not working as expected.

@robelgeda, as a consequence of moving `CubevizImageViewer`, all of the mouse move logic is now in `image_viewers.py`.