### PR TITLE
Bump version to 0.0.2 for DA-4 delivery

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ url = https://github.com/spacetelescope/cubeviz
 edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 0.1
+version = 0.0.2
 install_requires = numpy>=1.13 astropy asdf pytest==3.1 glue-core>=0.12 glueviz asteval
 
 [entry_points]

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ else:
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-VERSION = metadata.get('version', '0.0.dev')
+VERSION = metadata.get('version', '0.0.dev0')
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
cc @kassin @larrybradley @brechmos-stsci 

I had to use `0.0.2` because `0.0.1` already exists from back when this project was named `cubetools`:

```
$ git tag -ln
0.0.1           Use astropy Cutout2D
```

**Note:** `version` will be reverted to `0.1.dev` in a followup PR.