### PR TITLE
Move sync buttons

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -99,6 +99,16 @@ class CubeVizLayout(QtWidgets.QWidget):
         self.cube_views = self.all_views
         self.split_views = self.cube_views[1:]
 
+        self._synced_checkboxes = [
+            self.ui.singleviewer_synced_checkbox,
+            self.ui.viewer1_synced_checkbox,
+            self.ui.viewer2_synced_checkbox,
+            self.ui.viewer3_synced_checkbox
+        ]
+
+        for view, checkbox in zip(self.all_views, self._synced_checkboxes):
+            view._widget.assign_synced_checkbox(checkbox)
+
         # Add the views to the layouts.
         self.ui.single_image_layout.addWidget(self.single_view)
         self.ui.image_row_layout.addWidget(self.left_view)
@@ -267,9 +277,8 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._data = data
         self.specviz._widget.add_data(data)
 
-        # Syncing should only be enabled by default for cube viewers
-        for cube in self.cube_views:
-            cube._widget.enable_toolbar()
+        for checkbox in self._synced_checkboxes:
+            checkbox.setEnabled(True)
 
         self._has_data = True
         self._active_view = self.left_view
@@ -388,7 +397,7 @@ class CubeVizLayout(QtWidgets.QWidget):
     def _on_sync_click(self, event=None):
         index = self._active_cube._widget.slice_index
         for view in self.cube_views:
-            view._widget.set_sync_button()
+            view._widget.synced = True
             if view != self._active_cube:
                 view._widget.update_slice_index(index)
         self._slice_controller.update_index(index)

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1676</width>
-    <height>583</height>
+    <width>1553</width>
+    <height>550</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -469,7 +469,7 @@
         <property name="currentIndex">
          <number>1</number>
         </property>
-        <widget class="QWidget" name="stackedWidget_3Page1" native="true">
+        <widget class="QWidget" name="stackedWidget_3Page1">
          <layout class="QGridLayout" name="gridLayout_3">
           <property name="topMargin">
            <number>6</number>
@@ -489,35 +489,42 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
-             <item row="0" column="1">
-              <widget class="QLabel" name="label_5">
-               <property name="font">
-                <font>
-                 <pointsize>13</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>Viewer 2</string>
-               </property>
-              </widget>
+             <item row="0" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QLabel" name="label_4">
+                 <property name="font">
+                  <font>
+                   <pointsize>13</pointsize>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                   <underline>false</underline>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Viewer 1</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="viewer1_synced_checkbox">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Synced</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                 <property name="tristate">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="label_6">
-               <property name="font">
-                <font>
-                 <pointsize>13</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>Viewer 3</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
+             <item row="2" column="0">
               <widget class="QComboBox" name="viewer1_combo">
                <property name="enabled">
                 <bool>false</bool>
@@ -532,7 +539,7 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <item row="2" column="1">
               <widget class="QComboBox" name="viewer2_combo">
                <property name="enabled">
                 <bool>false</bool>
@@ -547,7 +554,7 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="2">
+             <item row="2" column="2">
               <widget class="QComboBox" name="viewer3_combo">
                <property name="enabled">
                 <bool>false</bool>
@@ -562,20 +569,73 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_4">
-               <property name="font">
-                <font>
-                 <pointsize>13</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                 <underline>false</underline>
-                </font>
-               </property>
-               <property name="text">
-                <string>Viewer 1</string>
-               </property>
-              </widget>
+             <item row="0" column="1">
+              <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <item>
+                <widget class="QLabel" name="label_5">
+                 <property name="font">
+                  <font>
+                   <pointsize>13</pointsize>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Viewer 2</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="viewer2_synced_checkbox">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Synced</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                 <property name="tristate">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="2">
+              <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <item>
+                <widget class="QLabel" name="label_6">
+                 <property name="font">
+                  <font>
+                   <pointsize>13</pointsize>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Viewer 3</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="viewer3_synced_checkbox">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Synced</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                 <property name="tristate">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
            </widget>
@@ -596,19 +656,6 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_9">
-               <property name="font">
-                <font>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>Viewer Contents</string>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="0">
               <widget class="QComboBox" name="single_viewer_combo">
                <property name="enabled">
@@ -626,6 +673,39 @@
                 </font>
                </property>
               </widget>
+             </item>
+             <item row="0" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_5">
+               <item>
+                <widget class="QLabel" name="label_9">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Viewer Contents</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="singleviewer_synced_checkbox">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Synced</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                 <property name="tristate">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
            </widget>


### PR DESCRIPTION
This fixes #156. Instead of requesting changes to the way that `glue` handles buttons in the viewer toolbars, we have simply moved the sync controls out of the viewer toolbars. They are now in the same area as the dropdowns that control the contents of each viewer.