### PR TITLE
Fix pinned pytest version in default_install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ for root, dirs, files in os.walk(PACKAGENAME):
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
 # I'm not sure whether it makes sense to duplicate this here or not
-default_install_requires = 'astropy asdf pytest==3.1'
+default_install_requires = 'astropy asdf pytest>=3.1'
 install_requires = metadata.get(
     'install_requires', default_install_requires).strip().split()
 


### PR DESCRIPTION
This fixes a minor oversight. Pytest no longer needs to be pinned to a specific version. This was fixed in #161, but it was not reflected in the default fallback versions of packages.