### PR TITLE
Make proper glue dataset to hold moment maps

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -708,7 +708,7 @@ class CubevizImageViewer(ImageViewer):
                             string = string + " " + self._coords_format_function(ra, dec)
                 # Pixel Value:
                 v = arr[y][x]
-                string = "{0:1.4f} {1} ".format(v, self.component_unit_label) + string
+                string = "{0:.3e} {1} ".format(v, self.component_unit_label) + string
         # Add a gap to string and add to viewer.
         string += " "
         self._dont_update_status = True

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -681,6 +681,11 @@ class CubevizImageViewer(ImageViewer):
         if len(self.state.layers) > 0:
             # Get array arr that contains the image values
             # Default layer is layer at index 0.
+            for layer in self.state.layers:
+                if layer.layer is self.state.reference_data:
+                    arr = layer.get_sliced_data()
+            else:
+                raise Exception("Couldn't find layer corresponding to reference data")
             arr = self.state.layers[0].get_sliced_data()
             if 0 <= y < arr.shape[0] and 0 <= x < arr.shape[1]:
                 # if x and y are in bounds. Note: x and y are swapped in array.

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -324,7 +324,8 @@ class CubevizImageViewer(ImageViewer):
 
     def get_contour_array(self):
         if self.contour_component is None:
-            arr = self.state.layers[0].get_sliced_data()
+            layer_artist = self.first_visible_layer()
+            arr = layer_artist.state.get_sliced_data()
         else:
             data = self.state.layers_data[0]
             arr = data[self.contour_component][self.slice_index]
@@ -681,13 +682,7 @@ class CubevizImageViewer(ImageViewer):
         # If viewer has a layer.
         if len(self.state.layers) > 0:
 
-            # Pick first enabled layer
-            for layer_artist in self.layers:
-                if layer_artist.enabled and layer_artist.visible:
-                    arr = layer_artist.state.get_sliced_data()
-                    break
-            else:
-                raise Exception("Couldn't find layer corresponding to reference data")
+            arr = self.first_visible_layer().state.get_sliced_data()
 
             if 0 <= y < arr.shape[0] and 0 <= x < arr.shape[1]:
                 # if x and y are in bounds. Note: x and y are swapped in array.
@@ -715,6 +710,20 @@ class CubevizImageViewer(ImageViewer):
         self._dont_update_status = False
         self.coord_label.setText(string)
         return
+
+    def first_visible_layer(self):
+        layers = self.visible_layers()
+        if len(layers) == 0:
+            raise Exception("Couldn't find any visible layers")
+        else:
+            return layers[0]
+
+    def visible_layers(self):
+        layers = []
+        for layer_artist in self.layers:
+            if layer_artist.enabled and layer_artist.visible:
+                layers.append(layer_artist)
+        return layers
 
     def mouse_exited(self, event):
         """

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -540,13 +540,14 @@ class CubevizImageViewer(ImageViewer):
     def slice_index(self):
         return self._slice_index
 
-    def update_component_unit_label(self, component_label):
+    def update_component_unit_label(self, component_id):
         """
         Update component's unit label.
-        :param component_label: component id as a string
+        :param component_id: component id
         """
-        data = self.state.layers_data[0]
-        unit = str(data.get_component(component_label).units)
+
+        data = component_id.parent
+        unit = str(data.get_component(component_id).units)
         if unit:
             self.component_unit_label = "{0}".format(unit)
         else:
@@ -679,14 +680,16 @@ class CubevizImageViewer(ImageViewer):
 
         # If viewer has a layer.
         if len(self.state.layers) > 0:
+
             # Get array arr that contains the image values
             # Default layer is layer at index 0.
             for layer in self.state.layers:
                 if layer.layer is self.state.reference_data:
                     arr = layer.get_sliced_data()
+                    break
             else:
                 raise Exception("Couldn't find layer corresponding to reference data")
-            arr = self.state.layers[0].get_sliced_data()
+
             if 0 <= y < arr.shape[0] and 0 <= x < arr.shape[1]:
                 # if x and y are in bounds. Note: x and y are swapped in array.
                 # get value and check if wcs is obtainable

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -340,18 +340,18 @@ class CubevizImageViewer(ImageViewer):
 
         arr = self.get_contour_array()
 
-        vmax = arr.max()
+        vmax = np.nanmax(arr)
         if settings.vmax is not None:
             vmax = settings.vmax
 
-        vmin = arr.min()
+        vmin = np.nanmin(arr)
         if settings.vmin is not None:
             vmin = settings.vmin
 
         if settings.spacing is None:
             spacing = 1
             if vmax != vmin:
-                spacing = (vmax-vmin)/CONTOUR_DEFAULT_NUMBER_OF_LEVELSS
+                spacing = (vmax - vmin)/CONTOUR_DEFAULT_NUMBER_OF_LEVELSS
         else:
             spacing = settings.spacing
 

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -681,11 +681,10 @@ class CubevizImageViewer(ImageViewer):
         # If viewer has a layer.
         if len(self.state.layers) > 0:
 
-            # Get array arr that contains the image values
-            # Default layer is layer at index 0.
-            for layer in self.state.layers:
-                if layer.layer is self.state.reference_data:
-                    arr = layer.get_sliced_data()
+            # Pick first enabled layer
+            for layer_artist in self.layers:
+                if layer_artist.enabled and layer_artist.visible:
+                    arr = layer_artist.state.get_sliced_data()
                     break
             else:
                 raise Exception("Couldn't find layer corresponding to reference data")

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -290,20 +290,16 @@ class CubeVizLayout(QtWidgets.QWidget):
                                                      parent=self)
         operation_handler.exec_()
 
-    def add_new_data_component(self, name):
-        self._component_labels.append(str(name))
+    def add_new_data_component(self, component_id):
 
         self.refresh_viewer_combo_helpers()
 
         if self._active_view in self.all_views:
             view_index = self.all_views.index(self._active_view)
-            component_index = self._component_labels.index(str(name))
-            self.change_viewer_component(view_index, component_index)
+            self.change_viewer_component(view_index, component_id)
 
-    def remove_component(self, name):
-        if str(name) not in self._component_labels:
-            return
-        self._component_labels.remove(str(name))
+    def remove_data_component(self, component_id):
+        pass
 
     def _enable_option_buttons(self):
         for button in self._option_buttons:
@@ -400,21 +396,27 @@ class CubeVizLayout(QtWidgets.QWidget):
             view.update_component_unit_label(component)
             view.update_axes_title(component.label)
 
-    def change_viewer_component(self, view_index,
-                                component_index,
-                                force=False):
+    def change_viewer_component(self, view_index, component_id, force=False):
         """
         Given a viewer at an index view_index, change combo
         selection to component at an index component_index.
         :param view_index: int: Viewer index
-        :param component_index: int: Component index in viewer combo
+        :param component_id: ComponentID: Component ID in viewer combo
         :param force: bool: force change if component is already displayed.
         """
+
         if view_index == 0:
             combo_label = 'single_viewer_combo'
         else:
             combo_label = 'viewer{0}_combo'.format(view_index)
+
         combo = getattr(self.ui, combo_label)
+
+        if isinstance(component_id, int):
+            component_index = component_id
+        else:
+            component_index = combo.findData(component_id)
+
         if combo.currentIndex() == component_index and force:
             combo.currentIndexChanged.emit(component_index)
         else:
@@ -587,17 +589,19 @@ class CubeVizLayout(QtWidgets.QWidget):
         # For single and first viewer:
         for view_index in [0, 1]:
             view = self.all_views[view_index].widget()
-            component_index = self._component_labels.index(component_id)
-            self.change_viewer_component(view_index, component_index, force=True)
+            self.change_viewer_component(view_index, component_id, force=True)
             view.set_smoothing_preview(preview_function, preview_title)
 
     def end_smoothing_preview(self):
         """
         End preview and change viewer combo index to the first component.
         """
-        for view_index in [0,1]:
+        for view_index in [0, 1]:
             view = self.all_views[view_index].widget()
             view.end_smoothing_preview()
+            # TODO: we shouldn't refer to the index in the combo, it would be
+            # better to refer to the component ID. Also not clear why we
+            # go back to the very fist item in the combo.
             self.change_viewer_component(view_index, 0, force=True)
 
     def showEvent(self, event):

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -311,7 +311,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             button.setEnabled(True)
         self.ui.sync_button.setEnabled(True)
 
-    def _get_change_viewer_func(self, view_index):
+    def _get_change_viewer_func(self, combo, view_index):
         def change_viewer(dropdown_index):
             view = self.all_views[view_index].widget()
             label = self._component_labels[dropdown_index]
@@ -320,7 +320,9 @@ class CubeVizLayout(QtWidgets.QWidget):
             view.update_component_unit_label(label)
             view.update_axes_title(title=str(label))
             view.state.layers[0]._update_attribute()
-            view.state.layers[0].attribute = self._data.id[label]
+            component = combo.currentData()
+            view.state.reference_data = component.parent
+            view.state.layers[0].attribute = component
             if view.is_contour_active:
                 view.draw_contour()
 
@@ -332,7 +334,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         helper = ComponentIDComboHelper(self, selection_label)
         helper.set_multiple_data([data])
         combo.setEnabled(True)
-        combo.currentIndexChanged.connect(self._get_change_viewer_func(index))
+        combo.currentIndexChanged.connect(self._get_change_viewer_func(combo, index))
         self._viewer_combo_helpers.append(helper)
 
     def _enable_all_viewer_combos(self, data):

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -57,7 +57,7 @@ class CubevizManager(HubListener):
         self._layout.add_new_data_component(message.component_id)
 
     def handle_remove_component(self, message):
-        self._layout.remove_component(message.component_id)
+        self._layout.remove_data_component(message.component_id)
 
     def handle_settings_change(self, message):
         if self._layout is not None:

--- a/cubeviz/tools/collapse_cube.py
+++ b/cubeviz/tools/collapse_cube.py
@@ -1,15 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
+import re
+
+import numpy as np
+
 from qtpy.QtCore import Qt
 from qtpy import QtGui
-from qtpy.QtWidgets import (
-    QDialog, QApplication, QPushButton,
-    QLabel, QWidget, QHBoxLayout, QVBoxLayout, QLineEdit, QComboBox
-)
+from qtpy.QtWidgets import (QDialog, QApplication, QPushButton, QLabel, QWidget,
+                            QHBoxLayout, QVBoxLayout, QLineEdit, QComboBox)
 
 from astropy.stats import sigma_clip
-import numpy as np
-import re
+
+from .common import add_to_2d_container
 
 # The operations we understand
 operations = {
@@ -486,7 +488,7 @@ class CollapseCube(QDialog):
                 sigma_iters = None
 
             new_component = sigma_clip(new_component, sigma=sigma, sigma_lower=sigma_lower,
-                                                     sigma_upper=sigma_upper, iters=sigma_iters)
+                                       sigma_upper=sigma_upper, iters=sigma_iters)
 
             # Add to label so it is clear which overlay/component is which
             if sigma:
@@ -501,7 +503,10 @@ class CollapseCube(QDialog):
             if sigma_iters:
                 label += ' sigma_iters={}'.format(sigma_iters)
 
-        # Add new overlay/component to cubeviz
+        # Add new overlay/component to cubeviz. We add this both to the 2D
+        # container Data object and also as an overlay. In future we might be
+        # able to use the 2D container Data object for the overlays directly.
+        add_to_2d_container(self.parent, self.data, new_component, label)
         self.parent.add_overlay(new_component, label)
 
         self.close()

--- a/cubeviz/tools/common.py
+++ b/cubeviz/tools/common.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function
+
+from glue.core import Data
+from glue.core.link_helpers import LinkSame
+from glue.core.coordinates import WCSCoordinates
+
+
+def add_to_2d_container(cubeviz_layout, data, component_data, label):
+    """
+    Given the cubeviz layout, a data object, a new 2D layer and a label, add
+    the 2D layer to the data object and update the cubeviz layout accordingly.
+    This creates the 2D container dataset if needed.
+    """
+
+    # If the 2D container doesn't exist, we create it here. This container is
+    # basically just a Data object but we keep it in an attribute
+    # ``container_2d`` on its parent dataset.
+    if getattr(data, 'container_2d', None) is None:
+
+        # For now, we assume that the 2D maps are always computed along the
+        # spectral axis, so that the resulting WCS is always celestial
+        coords = WCSCoordinates(wcs=data.coords.wcs.celestial)
+        data.container_2d = Data(label=data.label + " [2d]", coords=coords)
+
+        data.container_2d.add_component(component_data, label)
+
+        cubeviz_layout.session.data_collection.append(data.container_2d)
+
+        # Set up pixel links so that selections in the image plane propagate
+        # between 1D and 2D views. Again this assumes as above that the
+        # moments are computed along the spectral axis
+        link1 = LinkSame(data.pixel_component_ids[2],
+                         data.container_2d.pixel_component_ids[1])
+        link2 = LinkSame(data.pixel_component_ids[1],
+                         data.container_2d.pixel_component_ids[0])
+        cubeviz_layout.session.data_collection.add_link(link1)
+        cubeviz_layout.session.data_collection.add_link(link2)
+
+        for helper in cubeviz_layout._viewer_combo_helpers:
+            helper.append_data(data.container_2d)
+
+        for viewer in cubeviz_layout.all_views:
+            viewer._widget.add_data(data.container_2d)
+
+    else:
+
+        data.container_2d.add_component(component_data, label)

--- a/cubeviz/tools/moment_maps.py
+++ b/cubeviz/tools/moment_maps.py
@@ -115,8 +115,8 @@ class MomentMapsGUI(QDialog):
             self.data_collection.add_link(link2)
             for helper in self.parent._viewer_combo_helpers:
                 helper.append_data(self.data.container_2d)
-            # for viewer in self.parent.all_views:
-            #     viewer._widget.add_data(self.data.container_2d)
+            for viewer in self.parent.all_views:
+                viewer._widget.add_data(self.data.container_2d)
 
     def calculate_callback(self):
         """

--- a/cubeviz/tools/moment_maps.py
+++ b/cubeviz/tools/moment_maps.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from glue.core import Data
 from qtpy.QtCore import Qt
 from qtpy import QtGui
 from qtpy.QtWidgets import (
@@ -23,6 +24,7 @@ class MomentMapsGUI(QDialog):
         self.data = data
         self.data_collection = data_collection
         self.parent = parent
+        self._moments_container = None
 
         self.currentAxes = None
         self.currentKernel = None
@@ -89,6 +91,17 @@ class MomentMapsGUI(QDialog):
         self.setMaximumWidth(700)
         self.show()
 
+    def add_to_moment_container(self, data, label):
+        if self._moments_container is None:
+            self._moments_container = Data(label='Moments')
+            first = True
+        self._moments_container.add_component(data, label)
+        if first:
+            self.data_collection.append(self._moments_container)
+            for helper in self.parent._viewer_combo_helpers:
+                helper.append_data(self._moments_container)
+            for viewer in self.parent.all_views:
+                viewer._widget.add_data(self._moments_container)
 
     def calculate_callback(self):
         """
@@ -111,6 +124,7 @@ class MomentMapsGUI(QDialog):
             cube_moment = cube.moment(order=order, axis=0)
 
             label = '{}-moment-{}'.format(data_name, order)
+            self.add_to_moment_container(cube_moment.value, label)
             self.parent.add_overlay(cube_moment.value, label)
 
         except Exception as e:

--- a/cubeviz/tools/moment_maps.py
+++ b/cubeviz/tools/moment_maps.py
@@ -24,7 +24,6 @@ class MomentMapsGUI(QDialog):
         self.data = data
         self.data_collection = data_collection
         self.parent = parent
-        self._moments_container = None
 
         self.currentAxes = None
         self.currentKernel = None
@@ -92,16 +91,18 @@ class MomentMapsGUI(QDialog):
         self.show()
 
     def add_to_moment_container(self, data, label):
-        if self._moments_container is None:
-            self._moments_container = Data(label='Moments')
+        if getattr(self.data, 'container_2d', None) is None:
+            self.data.container_2d = Data(label=self.data.label + " [2d]")
             first = True
-        self._moments_container.add_component(data, label)
+        else:
+            first = False
+        self.data.container_2d.add_component(data, label)
         if first:
-            self.data_collection.append(self._moments_container)
+            self.data_collection.append(self.data.container_2d)
             for helper in self.parent._viewer_combo_helpers:
-                helper.append_data(self._moments_container)
+                helper.append_data(self.data.container_2d)
             for viewer in self.parent.all_views:
-                viewer._widget.add_data(self._moments_container)
+                viewer._widget.add_data(self.data.container_2d)
 
     def calculate_callback(self):
         """

--- a/cubeviz/tools/smoothing.py
+++ b/cubeviz/tools/smoothing.py
@@ -842,7 +842,7 @@ class SelectSmoothing(QDialog):
 
         preview_function = self.smooth_cube.preview_smoothing
         preview_title = self.smooth_cube.get_preview_title()
-        component_id = str(self.component_combo.currentText())
+        component_id = self.component_combo.currentData()
         self.parent.start_smoothing_preview(preview_function, component_id, preview_title)
 
         self.is_preview_active = True

--- a/cubeviz/tools/smoothing.py
+++ b/cubeviz/tools/smoothing.py
@@ -8,6 +8,7 @@ from astropy import convolution
 from glue.core import Data, Subset
 from glue.core.coordinates import coordinates_from_header, WCSCoordinates
 from glue.core.exceptions import IncompatibleAttribute
+from glue.utils.qt import update_combobox
 
 from spectral_cube import SpectralCube, BooleanArrayMask
 
@@ -422,7 +423,7 @@ class SmoothCube(object):
             return ndimage.filters.median_filter(data, self.kernel_size)
         else:
             kernel = self.get_kernel()
-            return convolution.convolve(data, kernel, normalize_kernel = True)
+            return convolution.convolve(data, kernel, normalize_kernel=True)
 
     def get_preview_title(self):
         title = "Smoothing Preview: "
@@ -627,15 +628,17 @@ class SelectSmoothing(QDialog):
         self.component_prompt.setWordWrap(True)
         self.component_prompt.setMinimumWidth(150)
         # Load component_ids and add to drop down
-        component_ids = [str(i) for i in self.data.component_ids()]
-        if self.parent is not None:
-            if hasattr(self.parent, "_component_labels"):
-                component_ids = self.parent._component_labels
+
+        # Add the data component labels to the drop down, with the ComponentID
+        # set as the userData:
+
+        if self.parent is not None and hasattr(self.parent, 'data_components'):
+            labeldata = [(str(cid), cid) for cid in self.parent.data_components]
+        else:
+            labeldata = [(str(cid), cid) for cid in self.data.main_components()]
 
         self.component_combo = QComboBox()
-        self.component_combo.addItems(
-            component_ids
-        )
+        update_combobox(self.component_combo, labeldata)
 
         self.component_combo.setMaximumWidth(150)
         self.component_combo.setCurrentIndex(0)


### PR DESCRIPTION
The idea here is to store the moment maps in a separate glue dataset rather than just internally in the cubeviz layout. There are several benefits to doing this:

* We can use the glue machinery to deal with showing the overlay rather than having to maintain our own custom way of doing it (since the glue image viewers allow multiple layers to be shown with transparency)

* We can show *just* a moment map in one of the viewers, we don't have to show it as an overlay

* We can also open a new tab and use the moment maps as a full glue dataset.