### PR TITLE
Read the docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,6 @@
 conda:
-  file: .rtd-environment.yml
+  file: test-environment.yml
 
 python:
    setup_py_install: true
+   version: 3.6

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,4 +3,4 @@ conda:
 
 python:
    setup_py_install: true
-   version: 3.6
+   version: 3.5


### PR DESCRIPTION
There were a couple small changes that had to happen in order to get the builds to work on the Read the Docs.  With the two changes below we now have a page http://cubeviz.readthedocs.io/en/latest/:

![image](https://user-images.githubusercontent.com/18348847/35285739-29a71b30-002c-11e8-9e8d-cb1e761be7bd.png)
