### PR TITLE
Bad data popup

### DIFF
--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -6,6 +6,11 @@ from glue.app.qt import GlueApplication
 from glue.main import restore_session, get_splash, load_data_files, load_plugins
 from qtpy.QtCore import QTimer
 
+try:
+    from glue.utils.qt.decorators import die_on_error
+except ImportError:
+    from glue.utils.decorators import die_on_error
+
 from .version import version as cubeviz_version
 
 # Global variable to store the data configuration directories/files
@@ -23,6 +28,7 @@ def setup():
     from . import layout  # noqa
     from . import startup  # noqa
 
+@die_on_error("Error starting up Cubeviz")
 def main(argv=sys.argv):
     """
     The majority of the code in this function was taken from start_glue() in main.py after a discussion with

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -40,9 +40,8 @@ def main(argv=sys.argv):
     args = parser.parse_known_args(argv[1:])
 
     # Store the args for each ' --data-configs' found on the commandline
-    data_configuration = {}
-    data_configuration['data_configs'] = args[0].data_configs if args[0].data_configs else []
-    data_configuration['data_configs_show'] = args[0].data_configs_show
+    data_configs = args[0].data_configs if args[0].data_configs else []
+    data_configs_show = args[0].data_configs_show
 
     import glue
     from glue.utils.qt import get_qapp
@@ -58,8 +57,7 @@ def main(argv=sys.argv):
     load_plugins(splash=splash)
 
     # Load the
-    DataFactoryConfiguration(data_configuration.get('data_configs', []),
-                             data_configuration.get('data_configs_show', False), remove_defaults=True)
+    DataFactoryConfiguration(data_configs, data_configs_show, remove_defaults=True)
 
     datafiles = args[0].data_files
 

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -34,13 +34,13 @@ def main(argv=sys.argv):
 
     # # Parse the arguments, ignore any unkonwn
     parser = argparse.ArgumentParser()
-    parser.add_argument("--data-configs", help="Directory or file for data configuration YAML files", action='append')
+    parser.add_argument("--data-configs", help="Directory or file for data configuration YAML files", action='append', default=[])
     parser.add_argument("--data-configs-show", help="Show the matching info", action="store_true", default=False)
     parser.add_argument('data_files', nargs=argparse.REMAINDER)
     args = parser.parse_known_args(argv[1:])
 
     # Store the args for each ' --data-configs' found on the commandline
-    data_configs = args[0].data_configs if args[0].data_configs else []
+    data_configs = args[0].data_configs
     data_configs_show = args[0].data_configs_show
 
     import glue

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -12,21 +12,14 @@ except ImportError:
     from glue.utils.decorators import die_on_error
 
 from .version import version as cubeviz_version
+from .data_factories import DataFactoryConfiguration
 
-# Global variable to store the data configuration directories/files
-# read in from the argparse from the command line.
-# Yes, yes, we understand global variables aren't the best idea, but it
-# seems to make sense here.
-global_data_configuration = {}
 
 def setup():
 
-    from .data_factories import DataFactoryConfiguration
-    DataFactoryConfiguration(global_data_configuration.get('data_configs', []),
-                             global_data_configuration.get('data_configs_show', False), remove_defaults=True)
-
     from . import layout  # noqa
     from . import startup  # noqa
+
 
 @die_on_error("Error starting up Cubeviz")
 def main(argv=sys.argv):
@@ -47,9 +40,9 @@ def main(argv=sys.argv):
     args = parser.parse_known_args(argv[1:])
 
     # Store the args for each ' --data-configs' found on the commandline
-    global global_data_configuration
-    global_data_configuration['data_configs'] = args[0].data_configs if args[0].data_configs else []
-    global_data_configuration['data_configs_show'] = args[0].data_configs_show
+    data_configuration = {}
+    data_configuration['data_configs'] = args[0].data_configs if args[0].data_configs else []
+    data_configuration['data_configs_show'] = args[0].data_configs_show
 
     import glue
     from glue.utils.qt import get_qapp
@@ -64,9 +57,11 @@ def main(argv=sys.argv):
     # plugins.
     load_plugins(splash=splash)
 
-    datafiles = args[0].data_files
+    # Load the
+    DataFactoryConfiguration(data_configuration.get('data_configs', []),
+                             data_configuration.get('data_configs_show', False), remove_defaults=True)
 
-    hub = None
+    datafiles = args[0].data_files
 
     # Show the splash screen for 1 second
     timer = QTimer()

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -23,7 +23,7 @@ def setup():
 
     from .data_factories import DataFactoryConfiguration
     DataFactoryConfiguration(global_data_configuration.get('data_configs', []),
-                             global_data_configuration.get('data_configs_show', False))
+                             global_data_configuration.get('data_configs_show', False), remove_defaults=True)
 
     from . import layout  # noqa
     from . import startup  # noqa

--- a/cubeviz/data_factories/__init__.py
+++ b/cubeviz/data_factories/__init__.py
@@ -298,7 +298,7 @@ class DataFactoryConfiguration:
             dc = DataConfiguration(config_file)
             print(dc.summarize())
 
-    def __init__(self, in_configs=[], show_only=False):
+    def __init__(self, in_configs=[], show_only=False, remove_defaults=False):
         """
         The IFC takes either a directory (that contains YAML files), a list of directories (each of which contain
         YAML files) or a list of YAML files.  Each YAML file defines requirements
@@ -308,7 +308,8 @@ class DataFactoryConfiguration:
 
         # Remove all pre-defined data configuration loaders in Glue. Then, if a user tries to open an IFU FITS
         # file that is not known to us a popup will come up saying cubeviz does not recognize the data format.
-        data_factory._members = []
+        if remove_defaults:
+            data_factory._members = []
 
         if show_only:
             logger.setLevel(logging.DEBUG)

--- a/cubeviz/data_factories/__init__.py
+++ b/cubeviz/data_factories/__init__.py
@@ -306,6 +306,10 @@ class DataFactoryConfiguration:
         :param in_configs: Directory, list of directories, or list of files.
         """
 
+        # Remove all pre-defined data configuration loaders in Glue. Then, if a user tries to open an IFU FITS
+        # file that is not known to us a popup will come up saying cubeviz does not recognize the data format.
+        data_factory._members = []
+
         if show_only:
             logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
This will show a popup that says there is bad data if it is an unrecognized IFU datafile, OR if there is a problem with the data file and the data loader can't parse it.

One data file that fails will now popup:
![image](https://user-images.githubusercontent.com/18348847/36039069-73c90adc-0d8f-11e8-9384-217bd247e680.png)
rather than show a long traceback on the command line.

Another data file (a MUSE format that isn't recognized) now shows:
![image](https://user-images.githubusercontent.com/18348847/36039119-98040a3c-0d8f-11e8-85e7-7835c217934c.png)
rather than bringing up cubeviz with no data  in the image viewers.

Addresses #190 