### PR TITLE
Add channel to test-environment.yml to get latest version of glue

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -18,6 +18,7 @@
 name: cubeviz-testing
 channels:
   - glueviz/label/dev
+  - glueviz
 dependencies:
   - python=3.6
   - pyqt

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -28,7 +28,6 @@ dependencies:
   # installed as a framework
   - matplotlib
   - glue-core>=0.12
-  - glueviz
   - pip:
     - asteval
     - git+https://github.com/spacetelescope/specviz#egg=specviz


### PR DESCRIPTION
Without this additional channel, installing `glue-core` will be forced to fall back on an older (circa October) version since it can't pull in the latest dependencies.