### PR TITLE
Provide custom viewer toolbar modes that create new ROIs

### DIFF
--- a/cubeviz/__init__.py
+++ b/cubeviz/__init__.py
@@ -9,3 +9,7 @@ This is an Astropy affiliated package.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *
 # ----------------------------------------------------------------------------
+
+# This ensures that all custom toolbar modes are imported so that they are
+# registered by @viewer_tool and are available for use by CubeViz.
+from .toolbar_modes import *

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -40,8 +40,8 @@ class CubevizImageLayerArtist(ImageLayerArtist):
 
 class CubevizImageViewer(ImageViewer):
 
-    tools = ['select:rectangle', 'select:xrange', 'select:yrange',
-             'select:circle', 'select:polygon', 'image:contrast_bias']
+    tools = ['cubeviz:rectangle', 'cubeviz:circle', 'cubeviz:polygon',
+             'image:contrast_bias']
 
     def __init__(self, *args, **kwargs):
         super(CubevizImageViewer, self).__init__(*args, **kwargs)

--- a/cubeviz/toolbar_modes.py
+++ b/cubeviz/toolbar_modes.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This file provides custom toolbar modes for glue image viewers. These toolbar
+modes override the glue default behavior for ROI selection. This means that
+every time an ROI selection tool is used, it will automatically create a new
+ROI and subset, instead of updating the current ROI and subset.
+
+The toolbar modes in this module must be imported in order for them to be
+registered by glue. This is currently handled in the __init__.py file.
+"""
+
+from glue.config import viewer_tool
+from glue.viewers.common.qt.toolbar_mode import (RectangleMode, CircleMode,
+                                                 PolyMode)
+
+__all__ = ['CubevizRectangleMode', 'CubevizCircleMode', 'CubevizPolyMode']
+
+
+@viewer_tool
+class CubevizRectangleMode(RectangleMode):
+    tool_id = 'cubeviz:rectangle'
+    create_new_subset = True
+
+
+@viewer_tool
+class CubevizCircleMode(CircleMode):
+    tool_id = 'cubeviz:circle'
+    create_new_subset = True
+
+
+@viewer_tool
+class CubevizPolyMode(PolyMode):
+    tool_id = 'cubeviz:polygon'
+    creat_new_subset = True


### PR DESCRIPTION
This PR depends on updates to `glue` in this PR: https://github.com/glue-viz/glue/pull/1515. It should not be merged until the `glue` PR is merged.

The updates to `glue` allow ROI toolbar modes to indicate whether each click of the mode button should create a new ROI and subset. This is disabled by default, but this is the default behavior we want in `cubeviz`, so we create custom toolbar mode classes that override the `glue` default.

This partially addresses #171, and it fixes #134.