### PR TITLE
Use development version of spectral cube in environment file

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -30,5 +30,6 @@ dependencies:
   - glue-core>=0.12
   - pip:
     - asteval
+    - git+https://github.com/radio-astro-tools/spectral-cube#egg=spectral-cube
     - git+https://github.com/spacetelescope/specviz#egg=specviz
     - git+https://github.com/spacetelescope/cubeviz#egg=cubeviz


### PR DESCRIPTION
Make sure that testers who use `test-environment.yml` get the latest development version of `spectral-cube`.