### PR TITLE
Update CI configs to use latest development version of glue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ env:
         # are in astropy-ci-extras. If your package uses either of these,
         # add the channels to CONDA_CHANNELS along with any other channels
         # you want to use.
-        - CONDA_CHANNELS='astropy-ci-extras astropy'
+        - CONDA_CHANNELS='glueviz/label/dev glueviz astropy-ci-extras astropy'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
       # are in astropy-ci-extras. If your package uses either of these,
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
-      CONDA_CHANNELS: "astropy-ci-extras astropy glue/label/dev"
+      CONDA_CHANNELS: "glueviz/label/dev glueviz astropy-ci-extras astropy"
 
   matrix:
 


### PR DESCRIPTION
Several new and pending features of `cubeviz` depend on features in the development version of `glue`. This means that for the time being we should be running our CI tests against the latest development version of `glue`, rather than the latest stable release.