### PR TITLE
Pin conda version, add more conda output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
         # List other runtime dependencies for the package that are available as
         # conda packages here.
         - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.12 asdf'
+        - CONDA_VERSION=4.3.31
 
         # List other runtime dependencies for the package that are available as
         # pip packages here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,8 @@ install:
     # other dependencies.
 
 script:
+   - conda info
+   - conda list
    - $MAIN_CMD $SETUP_CMD
    - find cubeviz -name "*.ui" -exec grep "pointsize" {} \; >& font.log
    - test ! -s font.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ environment:
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
       CONDA_CHANNELS: "glueviz/label/dev glueviz astropy-ci-extras astropy"
+      CONDA_VERSION: "4.3.31"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,6 @@ install:
 build: false
 
 test_script:
+    - "conda info"
+    - "conda list"
     - "%CMD_IN_ENV% python setup.py test"


### PR DESCRIPTION
This PR pins the conda version used in the CI scripts to `4.3.31`. It also adds more output to the CI scripts about conda environments and package listings.