### PR TITLE
Removed automodapi as we don't need the api docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,8 +171,6 @@ if eval(setup_cfg.get('edit_on_github')):
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
 
-#extensions += ['sphinx_automodapi.automodapi']
-
 # -- Resolving issue number to links in changelog -----------------------------
 github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_project'])
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,8 +48,6 @@ Future functionality will include the ability to:
 Reference/API
 =============
 
-.. automodapi:: cubeviz  
-
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
We really don't need the automodapi in here as we are not providing a programming API to the user.  The automodapi was causing significant issues with read-the-docs and sphinx for some reason.

If, in the future, we feel like we need an auto generated API we will have to come back to this.