### PR TITLE
Flux Units

### DIFF
--- a/cubeviz/data_factories/__init__.py
+++ b/cubeviz/data_factories/__init__.py
@@ -67,6 +67,22 @@ class DataConfiguration:
         """
         Extract BUNIT from header.
         BUNIT contains the flux units
+            KEYWORD:   BUNIT
+            REFERENCE: FITS Standard
+            STATUS:    reserved
+            HDU:       image
+            VALUE:     string
+            COMMENT:   physical units of the array values
+            DEFINITION: The value field shall contain a character string,
+            describing the physical units in which the quantities in the array,
+            after application of BSCALE and BZERO, are expressed.   The units of
+            all FITS header keyword values, with the exception of measurements of
+            angles, should conform with the recommendations in the IAU Style
+            Manual. For angular measurements given as floating point values and
+            specified with reserved keywords, degrees are the recommended units
+            (with the units, if specified, given as 'deg').
+        For more info on header keys:
+        https://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html
         :param header: header
         :return: str: Shortened unit
         """

--- a/cubeviz/data_factories/__init__.py
+++ b/cubeviz/data_factories/__init__.py
@@ -98,6 +98,10 @@ class DataConfiguration:
                         # The data must be floating point as spectralcube is expecting floating point data
                         data.add_component(component=hdu.data.astype(np.float), label=component_name)
 
+                        if 'BUNIT' in hdu.header:
+                            c = data.get_component(component_name)
+                            c.units = str(hdu.header['BUNIT'])
+
             # For the purposes of exporting, we keep a reference to the original HDUList object
             data._cubeviz_hdulist = hdulist
 

--- a/cubeviz/data_factories/__init__.py
+++ b/cubeviz/data_factories/__init__.py
@@ -50,6 +50,11 @@ class DataConfiguration:
 
             self._data = cfg.get('data', None)
 
+            if 'flux_unit_replacements' in cfg:
+                self.flux_unit_replacements = cfg['flux_unit_replacements']
+            else:
+                self.flux_unit_replacements = {}
+
     @property
     def name(self):
         return self._name
@@ -60,15 +65,17 @@ class DataConfiguration:
 
     def get_units(self, header):
         """
-        Extract BUNIT from header
+        Extract BUNIT from header.
+        BUNIT contains the flux units
         :param header: header
         :return: str: Shortened unit
         """
         units = str(header['BUNIT'])
 
         # Unit label shorten depending on data type here
-        if 'MANGA' == self.type:
-            units = units.replace("Ang", "A")
+        for key in self.flux_unit_replacements:
+            if key in units:
+                units = units.replace(key, self.flux_unit_replacements[key])
         return units
 
     def load_data(self, data_filenames):

--- a/cubeviz/data_factories/__init__.py
+++ b/cubeviz/data_factories/__init__.py
@@ -58,6 +58,19 @@ class DataConfiguration:
     def type(self):
         return self._type
 
+    def get_units(self, header):
+        """
+        Extract BUNIT from header
+        :param header: header
+        :return: str: Shortened unit
+        """
+        units = str(header['BUNIT'])
+
+        # Unit label shorten depending on data type here
+        if 'MANGA' == self.type:
+            units = units.replace("Ang", "A")
+        return units
+
     def load_data(self, data_filenames):
         """
         Load the data based on the extensions defined in the matching YAML file.  THen
@@ -100,7 +113,7 @@ class DataConfiguration:
 
                         if 'BUNIT' in hdu.header:
                             c = data.get_component(component_name)
-                            c.units = str(hdu.header['BUNIT'])
+                            c.units = self.get_units(hdu.header)
 
             # For the purposes of exporting, we keep a reference to the original HDUList object
             data._cubeviz_hdulist = hdulist

--- a/cubeviz/data_factories/configurations/manga.yaml
+++ b/cubeviz/data_factories/configurations/manga.yaml
@@ -29,3 +29,8 @@ data:
         IVAR
     DQ:
         MASK
+
+# Unit label replacements
+flux_unit_replacements:
+    "erg/s/cm^2/Ang/spaxel":
+        "erg/s/cm^2/A/spaxel"

--- a/cubeviz/data_factories/configurations/manga.yaml
+++ b/cubeviz/data_factories/configurations/manga.yaml
@@ -32,5 +32,5 @@ data:
 
 # Unit label replacements
 flux_unit_replacements:
-    "erg/s/cm^2/Ang/spaxel":
+    erg/s/cm^2/Ang/spaxel:
         "erg/s/cm^2/A/spaxel"

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -372,7 +372,7 @@ class CubevizImageViewer(ImageViewer):
 
     def update_component_unit_label(self, component_label):
         """
-        Update component's label
+        Update component's unit label.
         :param component_label: component id as a string
         """
         data = self.state.layers_data[0]
@@ -412,7 +412,15 @@ class CubevizImageViewer(ImageViewer):
             self._coords_format_function = self._format_to_degree_string
 
     def message_changed_callback(self, event):
-        """Update current message"""
+        """
+        This will be used to swap tool messages and coords messages.
+        When coords are displayed, tool message is cleared.
+        So we save the tool message and update it when it changes.
+        This callback is for when the tool message changes and the
+        boolean associated is to ignore the tool messages from the
+        coordinate display.
+        :param event: str: New status bar message.
+        """
         if self._dont_update_status:
             return
         self.status_message = event

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -378,7 +378,7 @@ class CubevizImageViewer(ImageViewer):
         data = self.state.layers_data[0]
         unit = str(data.get_component(component_label).units)
         if unit:
-            self.component_unit_label = "[{0}]".format(unit)
+            self.component_unit_label = "{0}".format(unit)
         else:
             self.component_unit_label = ""
 

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -59,6 +59,8 @@ class CubevizImageViewer(ImageViewer):
         self._synced_checkbox = None
         self._slice_index = None
 
+        self.component_unit_label = ""  # String to hold units of data values
+
         self.is_mouse_over = False  # If mouse cursor is over viewer
         self.hold_coords = False  # Switch to hold current displayed coords
         self._coords_in_degrees = False  # Switch display coords to True=deg or False=Deg/Hr:Min:Sec
@@ -83,8 +85,12 @@ class CubevizImageViewer(ImageViewer):
         self.statusBar().addPermanentWidget(self.coord_label)
 
         # Connect matplotlib events to event handlers
+        self.statusBar().messageChanged.connect(self.message_changed_callback)
         self.figure.canvas.mpl_connect('motion_notify_event', self.mouse_move)
         self.figure.canvas.mpl_connect('axes_leave_event', self.mouse_exited)
+
+        self._dont_update_status = False  # Don't save statusBar message when coords are changing
+        self.status_message = self.statusBar().currentMessage()
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
         if layer.ndim == 1:
@@ -364,6 +370,18 @@ class CubevizImageViewer(ImageViewer):
     def slice_index(self):
         return self._slice_index
 
+    def update_component_unit_label(self, component_label):
+        """
+        Update component's label
+        :param component_label: component id as a string
+        """
+        data = self.state.layers_data[0]
+        unit = str(data.get_component(component_label).units)
+        if unit:
+            self.component_unit_label = "[{0}]".format(unit)
+        else:
+            self.component_unit_label = ""
+
     def get_coords(self):
         """
         Returns coord display string.
@@ -393,6 +411,12 @@ class CubevizImageViewer(ImageViewer):
             self._coords_in_degrees = True
             self._coords_format_function = self._format_to_degree_string
 
+    def message_changed_callback(self, event):
+        """Update current message"""
+        if self._dont_update_status:
+            return
+        self.status_message = event
+
     def clear_coords(self):
         """
         Reset coord display and mouse tracking variables.
@@ -405,6 +429,7 @@ class CubevizImageViewer(ImageViewer):
         self.x_mouse = None
         self.y_mouse = None
         self.coord_label.setText('')
+        self.statusBar().showMessage(self.status_message)
 
     def _format_to_degree_string(self, ra, dec):
         """
@@ -495,9 +520,12 @@ class CubevizImageViewer(ImageViewer):
                             string = string + " " + self._coords_format_function(ra, dec)
                 # Pixel Value:
                 v = arr[y][x]
-                string = "{:1.4f} ".format(v) + string
+                string = "{0:1.4f} {1} ".format(v, self.component_unit_label) + string
         # Add a gap to string and add to viewer.
         string += " "
+        self._dont_update_status = True
+        self.statusBar().clearMessage()
+        self._dont_update_status = False
         self.coord_label.setText(string)
         return
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -317,6 +317,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             view.state.layers[0].attribute = self._data.id[label]
             if view.is_contour_active:
                 view.draw_contour()
+            view.update_component_unit_label(label)
         return change_viewer
 
     def _enable_viewer_combo(self, data, index, combo_label, selection_label):
@@ -340,14 +341,18 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._enable_viewer_combo(
             data, 0, 'single_viewer_combo', 'single_viewer_attribute')
         view = self.all_views[0].widget()
-        view.update_axes_title(str(getattr(self, 'single_viewer_attribute')))
+        component_label = str(getattr(self, 'single_viewer_attribute'))
+        view.update_axes_title(component_label)
+        view.update_component_unit_label(component_label)
 
         for i in range(1,4):
             combo_label = 'viewer{0}_combo'.format(i)
             selection_label = 'viewer{0}_attribute'.format(i)
             self._enable_viewer_combo(data, i, combo_label, selection_label)
             view = self.all_views[i].widget()
-            view.update_axes_title(str(getattr(self, selection_label)))
+            component_label = str(getattr(self, selection_label))
+            view.update_axes_title(component_label)
+            view.update_component_unit_label(component_label)
 
     def change_viewer_component(self, view_index,
                                 component_index,
@@ -381,6 +386,8 @@ class CubeVizLayout(QtWidgets.QWidget):
         """
         self._data = data
         self.specviz._widget.add_data(data)
+        cid = self.specviz._widget._options_widget.file_att
+        dispatch.changed_units.emit(y=data.get_component(cid).units)
 
         for checkbox in self._synced_checkboxes:
             checkbox.setEnabled(True)


### PR DESCRIPTION
Added flux units to each component's units (i.e. `component.units`) as a string. SpecViz y axes and the coordinate displays now show this information. The data factory looks for a `BUNIT` key in the data file headers for each component and adds the unit to `component.units` as a string. If no unit is there it will display an empty string. 

Also, matplotlib messages and coordinate messages don't display at the same time on the status bar (they alternate), the matplotlib messages are hidden while the coords display is active and returns to the original status bar message one the mouse is out of the plotted area. 