### PR TITLE
Fix configuration of directories searched by pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,8 @@ show-response = 1
 
 [tool:pytest]
 minversion = 3.1
-norecursedirs = build docs/_build
+testpaths = "cubeviz" "docs"
+norecursedirs = docs/_build
 doctest_plus = enabled
 addopts = -p no:warnings -p no:logging
 


### PR DESCRIPTION
This will allow `pytest` to be run directly without the `setup.py test` command.