### PR TITLE
Fast Slider⚡️

### DIFF
--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -111,6 +111,10 @@ class SliceController:
         active_cube = self._cv_layout._active_cube
         active_widget = active_cube._widget
 
+        # *** WARNING: DO NOT USE MULTI-THREADING! ***
+        #       fast_draw_slice_at_index will
+        #       cause a crash
+
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
         if active_widget.synced and not self._cv_layout._single_viewer_mode:

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -142,7 +142,10 @@ class SliceController:
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
         for t in threads:
             t.join()
-        print(time()-t1, "\n")
+        if self._slider_flag:
+            print("Total Time[_on_slider_change][Optimized]:", time()-t1, "\n")
+        else:
+            print("Total Time[_on_slider_change][Default]:", time() - t1, "\n")
 
     def _on_slider_pressed(self):
         self._slider_flag = True
@@ -151,7 +154,6 @@ class SliceController:
         self._slider_flag = False
 
         from time import time
-        from threading import Thread
         t1 = time()
         index = self._slice_slider.value()
         cube_views = self._cv_layout.cube_views
@@ -178,7 +180,7 @@ class SliceController:
 
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
 
-        print(time() - t1, " Release\n")
+        print("Total Time[_on_slider_released][Default]:", time() - t1, "\n")
 
     def _update_slice_textboxes(self, index):
         """

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -127,7 +127,7 @@ class SliceController:
             for view in cube_views:
                 if view != active_cube and view._widget.synced:
                     if self._slider_flag:
-                        target = view._widget.preview_slice_at_index(index)
+                        target = view._widget.preview_slice_at_index
                         t = Thread(target=target, args=(index,))
                         t.start()
                         threads.append(t)

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -117,14 +117,14 @@ class SliceController:
             for view in cube_views:
                 if view._widget.synced:
                     if self._slider_flag:
-                        view._widget.preview_slice_at_index(index)
+                        view._widget.fast_draw_slice_at_index(index)
                     else:
                         view._widget.update_slice_index(index)
             self._cv_layout.synced_index = index
         else:
             # Update the image displayed in the slice in the active view
             if self._slider_flag:
-                active_widget.preview_slice_at_index(index)
+                active_widget.fast_draw_slice_at_index(index)
             else:
                 active_widget.update_slice_index(index)
 

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -106,46 +106,32 @@ class SliceController:
         :param event:
         :return:
         """
-        from time import time
-        from threading import Thread
-        t1 = time()
         index = self._slice_slider.value()
         cube_views = self._cv_layout.cube_views
         active_cube = self._cv_layout._active_cube
         active_widget = active_cube._widget
 
-        # Update the image displayed in the slice in the active view
-        if self._slider_flag:
-            active_widget.preview_slice_at_index(index)
-        else:
-            active_widget.update_slice_index(index)
-
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
-        threads = []
         if active_widget.synced and not self._cv_layout._single_viewer_mode:
             for view in cube_views:
-                if view != active_cube and view._widget.synced:
+                if view._widget.synced:
                     if self._slider_flag:
-                        target = view._widget.preview_slice_at_index
-                        t = Thread(target=target, args=(index,))
-                        t.start()
-                        threads.append(t)
+                        view._widget.preview_slice_at_index(index)
                     else:
                         view._widget.update_slice_index(index)
-                        #target = view._widget.update_slice_index
             self._cv_layout.synced_index = index
+        else:
+            # Update the image displayed in the slice in the active view
+            if self._slider_flag:
+                active_widget.preview_slice_at_index(index)
+            else:
+                active_widget.update_slice_index(index)
 
         # Now update the slice and wavelength text boxes
         self._update_slice_textboxes(index)
 
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
-        for t in threads:
-            t.join()
-        if self._slider_flag:
-            print("Total Time[_on_slider_change][Optimized]:", time()-t1, "\n")
-        else:
-            print("Total Time[_on_slider_change][Default]:", time() - t1, "\n")
 
     def _on_slider_pressed(self):
         self._slider_flag = True
@@ -153,34 +139,26 @@ class SliceController:
     def _on_slider_released(self):
         self._slider_flag = False
 
-        from time import time
-        t1 = time()
         index = self._slice_slider.value()
         cube_views = self._cv_layout.cube_views
         active_cube = self._cv_layout._active_cube
         active_widget = active_cube._widget
 
-        # Update the image displayed in the slice in the active view
-        if self._slider_flag:
-            active_widget.preview_slice_at_index(index)
-        else:
-            active_widget.update_slice_index(index)
-
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
-
         if active_widget.synced and not self._cv_layout._single_viewer_mode:
             for view in cube_views:
-                if view != active_cube and view._widget.synced:
+                if view._widget.synced:
                     view._widget.update_slice_index(index)
             self._cv_layout.synced_index = index
+        else:
+            # Update the image displayed in the slice in the active view
+            active_widget.update_slice_index(index)
 
         # Now update the slice and wavelength text boxes
         self._update_slice_textboxes(index)
 
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
-
-        print("Total Time[_on_slider_released][Default]:", time() - t1, "\n")
 
     def _update_slice_textboxes(self, index):
         """

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -21,6 +21,10 @@ class SliceController:
         self._wavelength_textbox_label = ui.wavelength_textbox_label
 
         self._slice_slider.valueChanged.connect(self._on_slider_change)
+        self._slice_slider.sliderPressed.connect(self._on_slider_pressed)
+        self._slice_slider.sliderReleased.connect(self._on_slider_released)
+        self._slider_flag = False
+
         self._slice_textbox.returnPressed.connect(self._on_text_slice_change)
         self._wavelength_textbox.returnPressed.connect(self._on_text_wavelength_change)
 
@@ -102,16 +106,67 @@ class SliceController:
         :param event:
         :return:
         """
+        from time import time
+        from threading import Thread
+        t1 = time()
         index = self._slice_slider.value()
         cube_views = self._cv_layout.cube_views
         active_cube = self._cv_layout._active_cube
         active_widget = active_cube._widget
 
         # Update the image displayed in the slice in the active view
-        active_widget.update_slice_index(index)
+        if self._slider_flag:
+            active_widget.preview_slice_at_index(index)
+        else:
+            active_widget.update_slice_index(index)
 
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
+        threads = []
+        if active_widget.synced and not self._cv_layout._single_viewer_mode:
+            for view in cube_views:
+                if view != active_cube and view._widget.synced:
+                    if self._slider_flag:
+                        target = view._widget.preview_slice_at_index(index)
+                        t = Thread(target=target, args=(index,))
+                        t.start()
+                        threads.append(t)
+                    else:
+                        view._widget.update_slice_index(index)
+                        #target = view._widget.update_slice_index
+            self._cv_layout.synced_index = index
+
+        # Now update the slice and wavelength text boxes
+        self._update_slice_textboxes(index)
+
+        specviz_dispatch.changed_dispersion_position.emit(pos=index)
+        for t in threads:
+            t.join()
+        print(time()-t1, "\n")
+
+    def _on_slider_pressed(self):
+        self._slider_flag = True
+
+    def _on_slider_released(self):
+        self._slider_flag = False
+
+        from time import time
+        from threading import Thread
+        t1 = time()
+        index = self._slice_slider.value()
+        cube_views = self._cv_layout.cube_views
+        active_cube = self._cv_layout._active_cube
+        active_widget = active_cube._widget
+
+        # Update the image displayed in the slice in the active view
+        if self._slider_flag:
+            active_widget.preview_slice_at_index(index)
+        else:
+            active_widget.update_slice_index(index)
+
+        # If the active widget is synced then we need to update the image
+        # in all the other synced views.
+
         if active_widget.synced and not self._cv_layout._single_viewer_mode:
             for view in cube_views:
                 if view != active_cube and view._widget.synced:
@@ -123,6 +178,7 @@ class SliceController:
 
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
 
+        print(time() - t1, " Release\n")
 
     def _update_slice_textboxes(self, index):
         """

--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -106,6 +106,8 @@ class SliceController:
         :param event:
         :return:
         """
+        from time import time
+        t1 = time()
         index = self._slice_slider.value()
         cube_views = self._cv_layout.cube_views
         active_cube = self._cv_layout._active_cube
@@ -132,12 +134,16 @@ class SliceController:
         self._update_slice_textboxes(index)
 
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
+        t = time()-t1
+        print("Time[_on_slider_change]: {}".format(t))
 
     def _on_slider_pressed(self):
         self._slider_flag = True
 
     def _on_slider_released(self):
         self._slider_flag = False
+        from time import time
+        t1 = time()
 
         index = self._slice_slider.value()
         cube_views = self._cv_layout.cube_views
@@ -159,6 +165,8 @@ class SliceController:
         self._update_slice_textboxes(index)
 
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
+        t = time() - t1
+        print("Time[_on_slider_released]: {}".format(t))
 
     def _update_slice_textboxes(self, index):
         """

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -75,6 +75,9 @@ def only_draw_axes_images(ax):
 
     # This function will draw the images in the artist list
     mimage._draw_list_compositing_images(renderer, ax, artists)
+    
+    if hasattr(ax, "coords"):
+        ax.coords.frame.draw(renderer)
 
     renderer.close_group('axes')
     ax._cachedRenderer = renderer

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -388,8 +388,7 @@ class CubevizImageViewer(ImageViewer):
             for c in self.contour.collections:
                 ax.draw_artist(c)
 
-        fig.canvas.update()
-
+        fig.canvas.blit()
 
     @property
     def synced(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -75,7 +75,7 @@ def only_draw_axes_images(ax):
 
     # This function will draw the images in the artist list
     mimage._draw_list_compositing_images(renderer, ax, artists)
-    
+
     if hasattr(ax, "coords"):
         ax.coords.frame.draw(renderer)
 

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -95,8 +95,6 @@ class CubevizImageViewer(ImageViewer):
         self._dont_update_status = False  # Don't save statusBar message when coords are changing
         self.status_message = self.statusBar().currentMessage()
 
-        self.background = None
-
     def get_data_layer_artist(self, layer=None, layer_state=None):
         if layer.ndim == 1:
             cls = self._scatter_artist
@@ -374,8 +372,6 @@ class CubevizImageViewer(ImageViewer):
 
         ax = self.axes
         fig = self.axes.figure
-        if self.background is None:
-            self.background = ax.figure.canvas.copy_from_bbox(ax.bbox)
 
         for layer in self.layers:
             if isinstance(layer, CubevizImageLayerArtist):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -26,22 +26,110 @@ import matplotlib.image as mimage
 __all__ = ['CubevizImageViewer']
 
 
+def only_draw_axes_images(ax):
+    """
+    This function is a modified version of
+    matplotlib.axes._base._AxesBase.draw
+    This version only updates the images
+    of the axes.
+    :param ax: axes with images to update
+    """
+    if not ax.get_visible():
+        return
+
+    renderer = ax._cachedRenderer
+    renderer.open_group('axes')
+
+    # prevent triggering call backs during the draw process
+    ax._stale = True
+
+    locator = ax.get_axes_locator()
+    if locator:
+        pos = locator(ax, renderer)
+        ax.apply_aspect(pos)
+    else:
+        ax.apply_aspect()
+
+    # This is the biggest modification
+    # Restrict the artists list to images
+    artists = ax.images
+    artists = sorted(artists, key=lambda x: x.zorder)
+
+    # rasterize artists with negative zorder
+    # if the minimum zorder is negative, start rasterization
+    rasterization_zorder = ax._rasterization_zorder
+    if (rasterization_zorder is not None and
+            artists and artists[0].zorder < rasterization_zorder):
+        renderer.start_rasterizing()
+        artists_rasterized = [a for a in artists
+                              if a.zorder < rasterization_zorder]
+        artists = [a for a in artists
+                   if a.zorder >= rasterization_zorder]
+    else:
+        artists_rasterized = []
+
+    if artists_rasterized:
+        for a in artists_rasterized:
+            a.draw(renderer)
+        renderer.stop_rasterizing()
+
+    # This function will draw the images in the artist list
+    mimage._draw_list_compositing_images(renderer, ax, artists)
+
+    renderer.close_group('axes')
+    ax._cachedRenderer = renderer
+    ax.stale = False
+
 class CubevizImageLayerState(ImageLayerState):
     """
     Sub-class of ImageLayerState that includes the ability to include smoothing
     on-the-fly.
     """
-
     preview_function = None
-    arr = None
+    slice_index_override = None
 
     def get_sliced_data(self, view=None):
-        if self.arr is not None:
-            data = self.arr
-        elif self.preview_function is not None:
-            data = super(CubevizImageLayerState, self).get_sliced_data()
+        """
+        Override and modify ImageLayerState.get_sliced_data.
+        Modifications:
+            1)  If CubevizImageLayerState.preview_function is
+                defined, apply the function to data before return.
+            2)  If CubevizImageLayerState.slice_index_override is
+                defined, change slice index to that value
+        :param view: image view
+        :return: 2D np.ndarray
+        """
+        slices, agg_func, transpose = self.viewer_state.numpy_slice_aggregation_transpose
+        full_view = slices
+        if self.slice_index_override is not None:
+            full_view[0] = self.slice_index_override
+        if view is not None and len(view) == 2:
+            x_axis = self.viewer_state.x_att.axis
+            y_axis = self.viewer_state.y_att.axis
+            full_view[x_axis] = view[1]
+            full_view[y_axis] = view[0]
+            view_applied = True
         else:
-            data = super(CubevizImageLayerState, self).get_sliced_data(view=view)
+            view_applied = False
+        image = self._get_image(view=full_view)
+
+        # Apply aggregation functions if needed
+        if image.ndim != len(agg_func):
+            raise ValueError("Sliced image dimensions ({0}) does not match "
+                             "aggregation function list ({1})"
+                             .format(image.ndim, len(agg_func)))
+        for axis in range(image.ndim - 1, -1, -1):
+            func = agg_func[axis]
+            if func is not None:
+                image = func(image, axis=axis)
+        if image.ndim != 2:
+            raise ValueError("Image after aggregation should have two dimensions")
+        if transpose:
+            image = image.transpose()
+        if view_applied or view is None or self.preview_function is not None:
+            data = image
+        else:
+            data = image[view]
 
         if self.preview_function is not None:
             return self.preview_function(data)
@@ -359,9 +447,15 @@ class CubevizImageViewer(ImageViewer):
         self._synced_checkbox.stateChanged.connect(self._synced_checkbox_callback)
 
     def update_slice_index(self, index):
+        """
+        Function to update image and slice index.
+        Redraws figure.
+        :param index: (int) slice index
+        """
+        # Reset slice index override
         for layer in self.layers:
             if isinstance(layer, CubevizImageLayerArtist):
-                layer.state.arr = None
+                layer.state.slice_index_override = None
 
         self._slice_index = index
         z, y, x = self.state.slices
@@ -370,46 +464,37 @@ class CubevizImageViewer(ImageViewer):
             self.draw_contour()
 
     def fast_draw_slice_at_index(self, index):
-        component = self.state.layers[0].attribute
-        data = self.state.layers_data[0]
-        arr = data[component][index]
+        """
+        Function to update the displayed image at a slice index
+        quickly. Used when the user is scrolling using a slider.
+        Utilizes a modified version of matplotlib's `axes.draw()`
+        function to only draw images then uses `fig.canvas.blit()`
+        to update the canvas.
+        :param index: (int) slice index
+        """
+        # draw_artist can only be used after an
+        # initial draw which caches the render
+        if self.axes._cachedRenderer is None:
+            self.update_slice_index(index)
+            return
 
-        fig = self.axes.figure
+        self._slice_index = index
 
+        # Set main image's slice index to index
         for layer in self.layers:
             if isinstance(layer, CubevizImageLayerArtist):
-                layer.state.arr = arr
+                layer.state.slice_index_override = index
+        # Invalidate cached data for image viewer
+        # Or else it will not be redrawn
         self.axes._composite_image.invalidate_cache()
 
+        # Redraw canvas images
+        fig = self.axes.figure
         for ax in fig.axes:
-            if ax is not self.axes:
-                continue
-            renderer = ax._cachedRenderer
-            rasterization_zorder = ax._rasterization_zorder
-            artists = ax.images
-            artists = sorted(artists, key=lambda x: x.zorder)
+            only_draw_axes_images(ax)
 
-            # for im in artists:
-            #     if hasattr(im, "invalidate_cache"):
-            #         im.invalidate_cache()
-
-            if (rasterization_zorder is not None and
-                    artists and artists[0].zorder < rasterization_zorder):
-                renderer.start_rasterizing()
-                artists_rasterized = [a for a in artists
-                                      if a.zorder < rasterization_zorder]
-                artists = [a for a in artists
-                           if a.zorder >= rasterization_zorder]
-            else:
-                artists_rasterized = []
-
-            if artists_rasterized:
-                for a in artists_rasterized:
-                    a.draw(renderer)
-                renderer.stop_rasterizing()
-
-            mimage._draw_list_compositing_images(renderer, ax, artists)
-
+        # Draw contour and its labels
+        ax = self.axes
         if self.is_contour_active:
             self.draw_contour(draw=False)
             for c in self.contour.collections:
@@ -417,6 +502,7 @@ class CubevizImageViewer(ImageViewer):
             for t in self.contour.labelTexts:
                 ax.draw_artist(t)
 
+        # update canvas using blit
         fig.canvas.blit()
 
     @property

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -495,7 +495,7 @@ class CubevizImageViewer(ImageViewer):
 
         # Draw contour and its labels
         ax = self.axes
-        if self.is_contour_active:
+        if self.is_contour_active and self.contour is not None:
             self.draw_contour(draw=False)
             for c in self.contour.collections:
                 ax.draw_artist(c)

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -383,10 +383,13 @@ class CubevizImageViewer(ImageViewer):
         im = self.axes.get_images()[0]
         im.invalidate_cache()
         ax.draw_artist(im)
+
         if self.is_contour_active:
             self.draw_contour(draw=False)
             for c in self.contour.collections:
                 ax.draw_artist(c)
+            for t in self.contour.labelTexts:
+                ax.draw_artist(t)
 
         fig.canvas.blit()
 

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -39,7 +39,6 @@ class CubevizImageLayerState(ImageLayerState):
             data = super(CubevizImageLayerState, self).get_sliced_data()
             return self.preview_function(data)
         elif self.arr is not None:
-            print('array override')
             return self.arr
         else:
             return super(CubevizImageLayerState, self).get_sliced_data(view=view)
@@ -368,17 +367,11 @@ class CubevizImageViewer(ImageViewer):
         if self.is_contour_active:
             self.draw_contour()
 
-
     def preview_slice_at_index(self, index):
-        from time import time
-        t1 = time()
-        #print(index, self.contour_component)
         component = self.state.layers[0].attribute
         data = self.state.layers_data[0]
         arr = data[component][index]
-        print("array", time()-t1)
 
-        t1 = time()
         ax = self.axes
         fig = self.axes.figure
         if self.background is None:
@@ -387,18 +380,11 @@ class CubevizImageViewer(ImageViewer):
         for layer in self.layers:
             if isinstance(layer, CubevizImageLayerArtist):
                 layer.state.arr = arr
-        #ax.figure.canvas.restore_region(self.background)
+
         im = self.axes.get_images()[0]
-        #im.set_array(arr)
         im.invalidate_cache()
         ax.draw_artist(im)
         fig.canvas.update()
-        #fig.canvas.flush_events()
-        #ax.redraw_in_frame()
-        #ax.draw_artist(im)
-        #ax.figure.canvas.blit(ax.bbox)
-        #self.axes.figure.canvas.draw()
-        print("draw", time() - t1)
 
     @property
     def synced(self):

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -457,10 +457,12 @@ class CubeVizLayout(QtWidgets.QWidget):
             self._single_viewer_mode = False
             self.ui.button_toggle_image_mode.setText('Single Image Viewer')
             self.ui.viewer_control_frame.setCurrentIndex(0)
-            if self.single_view._widget.synced:
-                for view in self.split_views:
+
+            for view in self.split_views:
+                if self.single_view._widget.synced:
                     if view._widget.synced:
                         view._widget.update_slice_index(self.single_view._widget.slice_index)
+                view._widget.update()
         # Currently in split image, moving to single image
         else:
             self._active_split_cube = self._active_cube
@@ -470,6 +472,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             self._single_viewer_mode = True
             self.ui.button_toggle_image_mode.setText('Split Image Viewer')
             self.ui.viewer_control_frame.setCurrentIndex(1)
+            self._active_view._widget.update()
 
         self.subWindowActivated.emit(new_active_view)
 


### PR DESCRIPTION

1) when slider moves, optimized version of the update index function is used. The top slider can be said to be used for slice preview because the image is only thing that gets updated (the axes labels, titles etc.. remain the same)
2) when slider is released a full update to the image viewers will occur. (same as the old code)

Still to come:

- [x]  This must work with previews

- [x]  this must work with contours and contour settings

- [x]  specviz slider needs to do the same thing?
