### PR TITLE
Small fixes for small bugs (Contours)

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -22,8 +22,8 @@ from glue.viewers.common.qt.tool import Tool
 
 from .utils.contour import ContourSettings
 
-DEFAULT_NUMBER_OF_CONTOUR_LEVELS = 8
-MAX_NUMBER_OF_CONTOUR_LEVELS = 1000
+CONTOUR_DEFAULT_NUMBER_OF_LEVELSS = 8
+CONTOUR_MAX_NUMBER_OF_LEVELS = 1000
 
 __all__ = ['CubevizImageViewer']
 
@@ -344,14 +344,14 @@ class CubevizImageViewer(ImageViewer):
         if settings.spacing is None:
             spacing = 1
             if vmax != vmin:
-                spacing = (vmax-vmin)/DEFAULT_NUMBER_OF_CONTOUR_LEVELS
+                spacing = (vmax-vmin)/CONTOUR_DEFAULT_NUMBER_OF_LEVELSS
         else:
             spacing = settings.spacing
 
         levels = np.arange(vmin, vmax, spacing)
         levels = np.append(levels, vmax)
 
-        if levels.size > MAX_NUMBER_OF_CONTOUR_LEVELS:
+        if levels.size > CONTOUR_MAX_NUMBER_OF_LEVELS:
             message = "The current contour spacing is too small and " \
                       "results in too many levels. Contour spacing " \
                       "settings have been reset to auto."
@@ -361,7 +361,7 @@ class CubevizImageViewer(ImageViewer):
             settings.data_spacing = spacing
             if settings.dialog is not None:
                 settings.dialog.custom_spacing_checkBox.setChecked(False)
-            spacing = (vmax - vmin)/DEFAULT_NUMBER_OF_CONTOUR_LEVELS
+            spacing = (vmax - vmin)/CONTOUR_DEFAULT_NUMBER_OF_LEVELSS
             levels = np.arange(vmin, vmax, spacing)
             levels = np.append(levels, vmax)
 
@@ -425,7 +425,7 @@ class CubevizImageViewer(ImageViewer):
         vmin = arr.min()
         spacing = 1
         if vmax != vmin:
-            spacing = (vmax - vmin)/DEFAULT_NUMBER_OF_CONTOUR_LEVELS
+            spacing = (vmax - vmin)/CONTOUR_DEFAULT_NUMBER_OF_LEVELSS
         self.contour_settings.data_max = vmax
         self.contour_settings.data_min = vmin
         self.contour_settings.data_spacing = spacing

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -244,7 +244,7 @@ class CubevizImageViewer(ImageViewer):
         if settings.spacing is None:
             spacing = 1
             if vmax != vmin:
-                spacing = (vmax-vmin)/6
+                spacing = (vmax-vmin)/8
         else:
             spacing = settings.spacing
 

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -326,7 +326,7 @@ class CubevizImageViewer(ImageViewer):
         vmin = arr.min()
         spacing = 1
         if vmax != vmin:
-            spacing = (vmax - vmin) / 6
+            spacing = (vmax - vmin)/DEFAULT_NUMBER_OF_CONTOUR_LEVELS
         self.contour_settings.data_max = vmax
         self.contour_settings.data_min = vmin
         self.contour_settings.data_spacing = spacing

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -280,21 +280,15 @@ class CubevizImageViewer(ImageViewer):
         change the `contour_component` class var
         :param args: arguments from toolbar
         """
-        self.is_contour_active = True
+
         components = self.cubeviz_layout.component_labels
         self.contour_component = pick_item(components, components,
                                            title='Custom Contour',
                                            label='Pick a component')
         if self.contour_component is None:
-            # Edit toolbar menu to check the off option
-            menu = self.toolbar.actions['cubeviz:contour'].menu()
-            actions = menu.actions()
-            for action in actions:
-                if 'Off' == action.text():
-                    action.setChecked(True)
-                    break
-            self.remove_contour()
+            return
         else:
+            self.is_contour_active = True
             self.draw_contour()
 
     def remove_contour(self, *args):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -256,10 +256,10 @@ class CubevizImageViewer(ImageViewer):
         if settings.add_contour_label:
             self.axes.clabel(self.contour, fontsize=settings.font_size)
 
+        settings.data_max = arr.max()
+        settings.data_min = arr.min()
+        settings.data_spacing = spacing
         if settings.dialog is not None:
-            settings.data_max = arr.max()
-            settings.data_min = arr.min()
-            settings.data_spacing = spacing
             settings.update_dialog()
 
         self.axes.figure.canvas.draw()

--- a/cubeviz/utils/contour.py
+++ b/cubeviz/utils/contour.py
@@ -310,7 +310,11 @@ class ContourOptionsDialog(QDialog):
         if self.is_vmax:
             self.is_vmax = False
             self.vmax_input.setDisabled(True)
-            self.vmax_input.setText(self.vmax_default_text)
+            vmax = ""
+            if self.contour_settings.data_max:
+                vmax = self.contour_settings.data_max
+                vmax = "{0:1.4f}".format(vmax)
+            self.vmax_input.setText(vmax)
             self.vmax_input.setStyleSheet("")
         else:
             self.is_vmax = True
@@ -321,7 +325,11 @@ class ContourOptionsDialog(QDialog):
         if self.is_vmin:
             self.is_vmin = False
             self.vmin_input.setDisabled(True)
-            self.vmin_input.setText(self.vmin_default_text)
+            vmin = ""
+            if self.contour_settings.data_min:
+                vmin = self.contour_settings.data_min
+                vmin = "{0:1.4f}".format(vmin)
+            self.vmax_input.setText(vmin)
             self.vmin_input.setStyleSheet("")
         else:
             self.is_vmin = True
@@ -636,5 +644,3 @@ class ContourSettings(object):
         elif self.spacing is not None:
             is_simple = False
         return is_simple
-    def bobo(self):
-        pass

--- a/cubeviz/utils/contour.py
+++ b/cubeviz/utils/contour.py
@@ -58,6 +58,10 @@ class ContourButton(Tool):
         """
         self.options = []
 
+        # WARNING: QAction labels are used to identify them.
+        #          Changing them can cause problems unless
+        #          all references are updated in this package.
+        
         component_action_group = QActionGroup(self.tool_bar)
 
         action = QAction("Off", self.tool_bar, checkable=True)

--- a/cubeviz/utils/contour.py
+++ b/cubeviz/utils/contour.py
@@ -287,7 +287,11 @@ class ContourOptionsDialog(QDialog):
         if self.is_custom_spacing:
             self.is_custom_spacing = False
             self.spacing_input.setDisabled(True)
-            self.spacing_input.setText(self.spacing_default_text)
+            spacing = ""
+            if self.contour_settings.data_spacing:
+                spacing = self.contour_settings.data_spacing
+                spacing = "{0:1.4f}".format(spacing)
+            self.spacing_input.setText(spacing)
             self.spacing_input.setStyleSheet("")
         else:
             self.is_custom_spacing = True

--- a/cubeviz/utils/contour.py
+++ b/cubeviz/utils/contour.py
@@ -636,3 +636,5 @@ class ContourSettings(object):
         elif self.spacing is not None:
             is_simple = False
         return is_simple
+    def bobo(self):
+        pass

--- a/cubeviz/utils/contour.py
+++ b/cubeviz/utils/contour.py
@@ -61,7 +61,6 @@ class ContourButton(Tool):
         # WARNING: QAction labels are used to identify them.
         #          Changing them can cause problems unless
         #          all references are updated in this package.
-        
         component_action_group = QActionGroup(self.tool_bar)
 
         action = QAction("Off", self.tool_bar, checkable=True)

--- a/cubeviz/utils/contour.py
+++ b/cubeviz/utils/contour.py
@@ -329,7 +329,7 @@ class ContourOptionsDialog(QDialog):
             if self.contour_settings.data_min:
                 vmin = self.contour_settings.data_min
                 vmin = "{0:1.4f}".format(vmin)
-            self.vmax_input.setText(vmin)
+            self.vmin_input.setText(vmin)
             self.vmin_input.setStyleSheet("")
         else:
             self.is_vmin = True


### PR DESCRIPTION
Small improvements:
1) If `Cancel` is selected while the component selection dialog is on, simply exit without resetting the contour settings.
2) Update contour settings dialog with current data values when custom min/max/spacing values are deslected
3) Increase the number of default contour levels to 8
4) Set a maximum limit for the number of contour levels. If max is surpassed warn user and auto set contour spacing.