### PR TITLE
More shortcuts

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -187,7 +187,8 @@ class CubevizImageViewer(ImageViewer):
         # Connect matplotlib events to event handlers
         self.statusBar().messageChanged.connect(self.message_changed_callback)
         self.figure.canvas.mpl_connect('motion_notify_event', self.mouse_move)
-        self.figure.canvas.mpl_connect('axes_leave_event', self.mouse_exited)
+        #self.figure.canvas.mpl_connect('axes_leave_event', self.mouse_exited)
+        self.figure.canvas.mpl_connect('figure_enter_event', self.turn_mouse_on)
 
         self._dont_update_status = False  # Don't save statusBar message when coords are changing
         self.status_message = self.statusBar().currentMessage()
@@ -550,15 +551,16 @@ class CubevizImageViewer(ImageViewer):
         """
         Returns coord display string.
         """
-        if not self.is_mouse_over:
-            return None
-        return self.coord_label.text()
+        if self.is_mouse_over:
+            return self.coord_label.text()
+        return None
 
     def toggle_hold_coords(self):
         """
         Switch hold_coords state
         """
         if self.hold_coords:
+            self.statusBar().showMessage("")
             self.hold_coords = False
         else:
             self.statusBar().showMessage("Frozen Coordinates")
@@ -595,7 +597,6 @@ class CubevizImageViewer(ImageViewer):
         If hold_coords is active (True), make changes
         only to indicate that the mouse is no longer over viewer.
         """
-        self.is_mouse_over = False
         if self.hold_coords:
             return
         self.x_mouse = None
@@ -651,6 +652,7 @@ class CubevizImageViewer(ImageViewer):
         """
         # Check if mouse is in widget but not on plot
         if not event.inaxes:
+            self.is_mouse_over = False
             self.clear_coords()
             return
         self.is_mouse_over = True
@@ -718,4 +720,8 @@ class CubevizImageViewer(ImageViewer):
         :param event: QEvent
         """
         self.clear_coords()
+        self.is_mouse_over = False
         return
+
+    def turn_mouse_on(self, event):
+        self.is_mouse_over = True

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -187,7 +187,6 @@ class CubevizImageViewer(ImageViewer):
         # Connect matplotlib events to event handlers
         self.statusBar().messageChanged.connect(self.message_changed_callback)
         self.figure.canvas.mpl_connect('motion_notify_event', self.mouse_move)
-        #self.figure.canvas.mpl_connect('axes_leave_event', self.mouse_exited)
         self.figure.canvas.mpl_connect('figure_enter_event', self.turn_mouse_on)
 
         self._dont_update_status = False  # Don't save statusBar message when coords are changing

--- a/cubeviz/keyboard_shortcuts.py
+++ b/cubeviz/keyboard_shortcuts.py
@@ -94,5 +94,4 @@ def remove_mpl_shortcuts_and_check_dupes():
                     plt.rcParams[param].remove(key)
 
 
-
 remove_mpl_shortcuts_and_check_dupes()

--- a/cubeviz/keyboard_shortcuts.py
+++ b/cubeviz/keyboard_shortcuts.py
@@ -85,11 +85,10 @@ def remove_mpl_shortcuts_and_check_dupes():
         elif ks >= 128:
             raise ValueError("Please refrain from using non-ASCII values for shortcuts")
 
-    # Remove matplotlib default shortcuts if they conflict with other shortcuts
+    # Remove MatPlotLib default shortcuts if they conflict with other shortcuts
     for param in plt.rcParams:
         if 'keymap' in param:
             for key in plt.rcParams[param]:
-                print(key.upper(), vt_shortcuts, ks_shortcuts)
                 if key.upper() in vt_shortcuts or key.upper() in ks_shortcuts:
                     plt.rcParams[param].remove(key)
 

--- a/cubeviz/keyboard_shortcuts.py
+++ b/cubeviz/keyboard_shortcuts.py
@@ -1,8 +1,10 @@
 from glue.config import keyboard_shortcut
 from qtpy import QtCore, QtWidgets, QtGui, compat
+from qtpy.QtWidgets import QApplication
+from glue.config import viewer_tool
+import matplotlib.pyplot as plt
 
 
-@keyboard_shortcut(QtCore.Qt.Key_Left, None)
 @keyboard_shortcut(QtCore.Qt.Key_A, None)
 def move_slider_left(session):
     """
@@ -14,7 +16,6 @@ def move_slider_left(session):
     curr_layout.change_slice_index(-1)
 
 
-@keyboard_shortcut(QtCore.Qt.Key_Right, None)
 @keyboard_shortcut(QtCore.Qt.Key_D, None)
 def move_slider_right(session):
     """
@@ -24,3 +25,74 @@ def move_slider_right(session):
     """
     curr_layout = session.application.current_tab.ui
     curr_layout.change_slice_index(1)
+
+
+@keyboard_shortcut(QtCore.Qt.Key_F, None)
+def lock_coordinates(session):
+    """
+    Lock coordinates in the bottom right of the viewer window
+    :param session:
+    :return:
+    """
+    lay = session.application.current_tab
+    for w in lay.all_views:
+        civ = w._widget
+        if civ.is_mouse_over:
+            civ.toggle_hold_coords()
+
+
+@keyboard_shortcut(QtCore.Qt.Key_P, None)
+def copy_coordinates_to_clipboard(session):
+    """
+    Copy coordinates to clipboard so user can paste them elsewhere
+    :param session:
+    :return:
+    """
+    coords_status = False
+    lay = session.application.current_tab
+    for w in lay.all_views:
+        civ = w._widget
+        if civ.is_mouse_over:
+            coords_status = civ.get_coords()
+            break
+
+    if coords_status:
+        cb = QApplication.clipboard()
+        cb.clear(mode=cb.Clipboard)
+        cb.setText(coords_status, mode=cb.Clipboard)
+
+
+def remove_mpl_shortcuts_and_check_dupes():
+    """
+    Makes sure that shortcut keys do not overlap between the three things (glue.config.viewer_tool, MatPlotLib,
+    and keyboard_shortcuts) that use them
+    :return:
+    """
+    # Get all shortcuts from glue.config.viewer_tools
+    vt_shortcuts = []
+    for vt in viewer_tool.members:
+        if viewer_tool.members[vt].shortcut is not None:
+            vt_shortcuts.append(viewer_tool.members[vt].shortcut)
+
+    # If shortcut already exists in glue.config.viewer_tool, raise error
+    ks_shortcuts = []
+    for ks in keyboard_shortcut.members[None]:
+        if ks < 128 and chr(ks) in vt_shortcuts:
+            print("Make sure the shortcuts are NOT one of the following {0}\n\n".format(vt_shortcuts))
+            raise ValueError("Keyboard shortcut '{0}' already registered in {1}".format(chr(ks), "glue.config.viewer_tool"))
+        elif ks < 128:
+            ks_shortcuts.append(chr(ks))
+        elif ks >= 128:
+            raise ValueError("Please refrain from using non-ASCII values for shortcuts")
+
+    # Remove matplotlib default shortcuts if they conflict with other shortcuts
+    for param in plt.rcParams:
+        if 'keymap' in param:
+            for key in plt.rcParams[param]:
+                print(key.upper(), vt_shortcuts, ks_shortcuts)
+                if key.upper() in vt_shortcuts or key.upper() in ks_shortcuts:
+                    plt.rcParams[param].remove(key)
+
+
+
+remove_mpl_shortcuts_and_check_dupes()


### PR DESCRIPTION
# Added the following shortcuts

- A: move slice 1 to the left
- D: move slice 1 to the right
- F: freeze coordinates while hovering over a plot
- P: pull coordinates (frozen or not) into users clipboard, where they can be pasted anywhere