### PR TITLE
Revert "Pin MPL to 2.1 for now to work around glue bug"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # conda packages here.
-        - CONDA_DEPENDENCIES='pyqt matplotlib=2.1 scipy glue-core>=0.12 asdf'
+        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.12 asdf'
         - CONDA_VERSION=4.3.31
 
         # List other runtime dependencies for the package that are available as

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
       NUMPY_VERSION: "1.13"
       SPECVIZ_GIT: "git+https://github.com/spacetelescope/specviz#egg=specviz"
-      CONDA_DEPENDENCIES: "pyqt matplotlib=2.1 scipy glue-core>=0.12 asdf"
+      CONDA_DEPENDENCIES: "pyqt matplotlib scipy glue-core>=0.12 asdf"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - scipy
   # This is necessary in some OSX environments to ensure that Python is
   # installed as a framework
-  - matplotlib=2.1
+  - matplotlib
   - glue-core>=0.12
   - pip:
     - asteval


### PR DESCRIPTION
Reverts spacetelescope/cubeviz#276. Now that glue conda builds provide the bug fix with mpl-2.2.0 compatibility, this should be safe to revert.

Fixes #277.