### PR TITLE
removed unused menu items, will add in when the functionality is added

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -176,9 +176,6 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         # Create the View Menu
         view_menu = self._dict_to_menu(OrderedDict([
-            ('RA-DEC', lambda: None),
-            ('RA-Spectral', lambda: None),
-            ('DEC-Spectral', lambda: None),
             ('Hide Axes', ['checkable', self._toggle_viewer_axes]),
             ('Hide Toolbars', ['checkable', self._toggle_toolbars]),
             ('Wavelength Units', lambda: self._open_dialog('Wavelength Units', None))


### PR DESCRIPTION
Removed unused menu items so as not to confuse people using it. We can add them back in when the functionality exists.