### PR TITLE
Fix ROI selection

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -440,7 +440,10 @@ class CubeVizLayout(QtWidgets.QWidget):
                 for viewer in self.subWindowList():
                     relative_click_pos = viewer.mapFromGlobal(click_pos)
                     if viewer.rect().contains(relative_click_pos):
-                        self.subWindowActivated.emit(viewer)
+                        # We should only emit an event if the active subwindow
+                        # has actually changed.
+                        if viewer is not self.activeSubWindow():
+                            self.subWindowActivated.emit(viewer)
                         break
 
                 self._last_click = click_pos


### PR DESCRIPTION
Fix bug that caused ROI selection tools to get deselected as soon as the first click to make the selection was made. This is because in the latest developer version of glue, when a subWindowActivated event is emitted, we assume the viewer has changed and that the active tool should be deselected.

Ideally we should also do a similar check in glue to only deselect the active tool if the active viewer has changed - issue here: https://github.com/glue-viz/glue/issues/1601 - if anyone would be interested in working on that, feel free to, otherwise I'll get to it next week :)

Fixes #288