### PR TITLE
Make slice slider behavior consistent with 2D data components

### DIFF
--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -47,9 +47,7 @@ class SliceController:
 
         :return:
         """
-        self._slice_slider.setEnabled(True)
-        self._slice_textbox.setEnabled(True)
-        self._wavelength_textbox.setEnabled(True)
+        self.set_enabled(True)
 
         self._slice_slider.setMinimum(0)
 
@@ -69,6 +67,11 @@ class SliceController:
         self._wavelength_textbox.setText(self._wavelength_format.format(self._wavelengths[middle_index]))
 
         self._cv_layout.synced_index = middle_index
+
+    def set_enabled(self, value):
+        self._slice_slider.setEnabled(value)
+        self._slice_textbox.setEnabled(value)
+        self._wavelength_textbox.setEnabled(value)
 
     def set_wavelengths(self, new_wavelengths, new_units):
 

--- a/cubeviz/controls/tests/test_slice_controller.py
+++ b/cubeviz/controls/tests/test_slice_controller.py
@@ -7,24 +7,13 @@ import numpy as np
 
 from ...tests.helpers import (enter_slice_text, enter_wavelength_text,
                               left_click, select_viewer, enter_slice_text,
-                              toggle_viewer)
+                              toggle_viewer, assert_viewer_indices,
+                              assert_all_viewer_indices,
+                              assert_wavelength_text, assert_slice_text)
 
 
 def set_slider_index(layout, index):
     layout._slice_controller._slice_slider.setSliderPosition(index)
-
-def assert_viewer_indices(viewer_array, index):
-    for viewer in viewer_array:
-        assert viewer._widget.slice_index == index
-
-def assert_all_viewer_indices(layout, index):
-    assert_viewer_indices(layout.all_views, index)
-
-def assert_slice_text(layout, text):
-    assert layout._slice_controller._slice_textbox.text() == str(text)
-
-def assert_wavelength_text(layout, text):
-    assert layout._slice_controller._wavelength_textbox.text() == str(text)
 
 def find_nearest_slice(wavelengths, value):
     return np.argsort(abs(wavelengths - value))[0]

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -356,6 +356,11 @@ class CubeVizLayout(QtWidgets.QWidget):
                     # contrast tool, it will change the right layer
                     viewer._view.layer_list.select_artist(layer_artist)
 
+            # If the combo corresponds to the currently active cube viewer,
+            # either activate or deactivate the slice slider as appropriate.
+            if self.all_views[view_index] is self._active_cube:
+                self._slice_controller.set_enabled(not viewer.has_2d_data)
+
             # If contours are being currently shown, we need to force a redraw
             if viewer.is_contour_active:
                 viewer.draw_contour()
@@ -553,7 +558,11 @@ class CubeVizLayout(QtWidgets.QWidget):
             if isinstance(view._widget, CubevizImageViewer):
                 self._active_cube = view
                 index = self._active_cube._widget.slice_index
-                self._slice_controller.update_index(index)
+                if view._widget.has_2d_data:
+                    self._slice_controller.set_enabled(False)
+                else:
+                    self._slice_controller.set_enabled(True)
+                    self._slice_controller.update_index(index)
 
     def activeSubWindow(self):
         return self._active_view

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -255,8 +255,9 @@ class CubeVizLayout(QtWidgets.QWidget):
             ex = arithmetic_gui.SelectArithmetic(self._data, self.session.data_collection, parent=self)
 
         if name == "Moment Maps":
-            moment_maps.MomentMapsGUI(
+            mm_gui = moment_maps.MomentMapsGUI(
                 self._data, self.session.data_collection, parent=self)
+            mm_gui.display()
 
         if name == 'Wavelength Units':
             current_unit = self._units_controller.units_titles.index(self._units_controller._new_units.long_names[0].title())

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -319,6 +319,8 @@ class CubeVizLayout(QtWidgets.QWidget):
             label = combo.currentText()
             component = combo.currentData()
 
+            viewer.has_2d_data = component.parent[label].ndim == 2
+
             # If the user changed the current component, stop previewing
             # smoothing.
             if viewer.is_smoothing_preview_active:

--- a/cubeviz/tests/helpers.py
+++ b/cubeviz/tests/helpers.py
@@ -5,7 +5,9 @@ from glue.app.qt import GlueApplication
 
 
 __all__ = ['toggle_viewer', 'select_viewer', 'create_glue_app',
-           'reset_app_state']
+           'enter_slice_text', 'enter_wavelength_text', 'reset_app_state',
+           'sync_all_viewers', 'assert_all_viewer_indices',
+           'assert_slice_text']
 
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
@@ -40,6 +42,20 @@ def enter_wavelength_text(qtbot, layout, text):
 
 def sync_all_viewers(qtbot, layout):
     left_click(qtbot, layout.ui.sync_button)
+
+def assert_viewer_indices(viewer_array, index):
+    for viewer in viewer_array:
+        assert viewer._widget.slice_index == index
+
+def assert_all_viewer_indices(layout, index):
+    assert_viewer_indices(layout.all_views, index)
+
+def assert_wavelength_text(layout, text):
+    assert layout._slice_controller._wavelength_textbox.text() == str(text)
+
+def assert_slice_text(layout, text):
+    assert layout._slice_controller._slice_textbox.text() == str(text)
+
 
 def create_glue_app():
     filename = os.path.join(TEST_DATA_PATH, 'data_cube.fits.gz')


### PR DESCRIPTION
Now that 2D data components are supported (#169), we need to make sure that the wavelength slider does The Right Thing when 2D components are being displayed. It is also necessary to make sure that displaying a 2D data component in one viewer does not inadvertently alter the slice index being displayed for all other viewers.