### PR TITLE
ROI selection should create new ROIs by default

### DIFF
--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -21,6 +21,9 @@ class CubevizManager(HubListener):
         self._app.close_tab(0, warn=False)
         self.hide_sidebar()
 
+        # For cubeviz, ROI selection should be in 'NewMode' by default
+        self._app._mode_toolbar.set_mode('new')
+
         self._hub.subscribe(
             self, DataCollectionAddMessage, handler=self.handle_new_dataset)
         self._hub.subscribe(


### PR DESCRIPTION
This means the default behavior in cubeviz will be to create a new ROI and subset for every ROI selection. Glue already provides the ability to relocate ROIs by clicking and dragging them. It is possible to delete ROIs by right-clicking on them and selecting the option to delete from the context menu.

While I hope to implement more intuitive ROI selection behavior in glue in the future, it has turned out to be much more complicated than I had expected. I believe this minor change provides 95% of the functionality that was requested by @kassin et al.

This fixes #134. 