### PR TITLE
Display viewer options by default

### DIFF
--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -19,7 +19,6 @@ class CubevizManager(HubListener):
 
         self._empty_layout = self._app.add_fixed_layout_tab(CubeVizLayout)
         self._app.close_tab(0, warn=False)
-        self.hide_sidebar()
 
         self._hub.subscribe(
             self, DataCollectionAddMessage, handler=self.handle_new_dataset)

--- a/cubeviz/toolbar.py
+++ b/cubeviz/toolbar.py
@@ -10,7 +10,7 @@ class CubevizToolbar(QtWidgets.QToolBar):
         self.application = application
 
         self._button_viewer_options = QtWidgets.QPushButton()
-        self._button_viewer_options.setText("Show viewer options")
+        self._button_viewer_options.setText("Hide viewer options")
         self._button_viewer_options.clicked.connect(self._toggle_sidebar)
 
         self.addWidget(self._button_viewer_options)


### PR DESCRIPTION
This has come up in discussion several times now: it seems like we want to display the glue viewer options by default, while still allowing them to be hidden by the user. This PR makes the options display by default.