### PR TITLE
Get rid of named viewers in split layout

### DIFF
--- a/cubeviz/controls/tests/test_slice_controller.py
+++ b/cubeviz/controls/tests/test_slice_controller.py
@@ -163,8 +163,8 @@ def sync_params(cubeviz_layout, request):
 
     params = dict(
         checkbox=cubeviz_layout._synced_checkboxes[viewer_index],
-        unsynced_viewer=cubeviz_layout.all_views[viewer_index],
-        other_viewers=all_but_index(cubeviz_layout.all_views, viewer_index),
+        unsynced_viewer=cubeviz_layout.cube_views[viewer_index],
+        other_viewers=all_but_index(cubeviz_layout.cube_views, viewer_index),
         synced_viewer=all_but_index(
             cubeviz_layout.split_views, viewer_index-1)[0]
     )
@@ -255,17 +255,17 @@ def test_multiple_unsynced_viewers(qtbot, cubeviz_layout):
     # Sanity check to make sure all viewers are actually synced
     assert_all_viewer_indices(cubeviz_layout, synced_index)
 
-    unsync1 = cubeviz_layout.all_views[1]
+    unsync1 = cubeviz_layout.cube_views[1]
     checkbox1 = cubeviz_layout._synced_checkboxes[1]
     unsync_index1 = 42
 
-    unsync2 = cubeviz_layout.all_views[3]
+    unsync2 = cubeviz_layout.cube_views[3]
     checkbox2 = cubeviz_layout._synced_checkboxes[3]
     unsync_index2 = 1234
 
     remain_synced = [
-        cubeviz_layout.all_views[0],
-        cubeviz_layout.all_views[2]
+        cubeviz_layout.cube_views[0],
+        cubeviz_layout.cube_views[2]
     ]
 
     # Unsync the first viewer

--- a/cubeviz/keyboard_shortcuts.py
+++ b/cubeviz/keyboard_shortcuts.py
@@ -35,7 +35,7 @@ def lock_coordinates(session):
     :return:
     """
     lay = session.application.current_tab
-    for w in lay.all_views:
+    for w in lay.cube_views:
         civ = w._widget
         if civ.is_mouse_over:
             civ.toggle_hold_coords()
@@ -50,7 +50,7 @@ def copy_coordinates_to_clipboard(session):
     """
     coords_status = False
     lay = session.application.current_tab
-    for w in lay.all_views:
+    for w in lay.cube_views:
         civ = w._widget
         if civ.is_mouse_over:
             coords_status = civ.get_coords()

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -82,21 +82,19 @@ class CubeVizLayout(QtWidgets.QWidget):
         self.ui = load_ui('layout.ui', self,
                           directory=os.path.dirname(__file__))
 
-        self.all_views = []
+        self.cube_views = []
 
         # Create the cube viewers and register to the hub.
         for _ in range(DEFAULT_NUM_SPLIT_VIEWERS + 1):
             ww = WidgetWrapper(CubevizImageViewer(
                     self.session, cubeviz_layout=self), tab_widget=self)
-            self.all_views.append(ww)
+            self.cube_views.append(ww)
             ww._widget.register_to_hub(self.session.hub)
 
         # Create specviz viewer and register to the hub.
         self.specviz = WidgetWrapper(SpecVizViewer(self.session), tab_widget=self)
         self.specviz._widget.register_to_hub(self.session.hub)
 
-        # TODO: determine whether to rename this or get rid of it
-        self.cube_views = self.all_views
         self.single_view = self.cube_views[0]
         self.split_views = self.cube_views[1:]
 
@@ -107,7 +105,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             self.ui.viewer3_synced_checkbox
         ]
 
-        for view, checkbox in zip(self.all_views, self._synced_checkboxes):
+        for view, checkbox in zip(self.cube_views, self._synced_checkboxes):
             view._widget.assign_synced_checkbox(checkbox)
 
         # Add the views to the layouts.
@@ -331,8 +329,8 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         self.refresh_viewer_combo_helpers()
 
-        if self._active_view in self.all_views:
-            view_index = self.all_views.index(self._active_view)
+        if self._active_view in self.cube_views:
+            view_index = self.cube_views.index(self._active_view)
             self.change_viewer_component(view_index, component_id)
 
     def remove_data_component(self, component_id):
@@ -352,7 +350,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             # _get_change_viewer_combo_func function.
 
             # Find the relevant viewer
-            viewer = self.all_views[view_index].widget()
+            viewer = self.cube_views[view_index].widget()
 
             # Get the label of the component and the component ID itself
             label = combo.currentText()
@@ -397,7 +395,7 @@ class CubeVizLayout(QtWidgets.QWidget):
 
             # If the combo corresponds to the currently active cube viewer,
             # either activate or deactivate the slice slider as appropriate.
-            if self.all_views[view_index] is self._active_cube:
+            if self.cube_views[view_index] is self._active_cube:
                 self._slice_controller.set_enabled(not viewer.has_2d_data)
 
             # If contours are being currently shown, we need to force a redraw
@@ -426,7 +424,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         """
         self._enable_viewer_combo(
             data, 0, 'single_viewer_combo', 'single_viewer_attribute')
-        view = self.all_views[0].widget()
+        view = self.cube_views[0].widget()
         component = getattr(self, 'single_viewer_attribute')
         view.update_component_unit_label(component)
         view.update_axes_title(component.label)
@@ -435,7 +433,7 @@ class CubeVizLayout(QtWidgets.QWidget):
             combo_label = 'viewer{0}_combo'.format(i)
             selection_label = 'viewer{0}_attribute'.format(i)
             self._enable_viewer_combo(data, i, combo_label, selection_label)
-            view = self.all_views[i].widget()
+            view = self.cube_views[i].widget()
             component = getattr(self, selection_label)
             view.update_component_unit_label(component)
             view.update_axes_title(component.label)
@@ -641,7 +639,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         return self._active_view
 
     def subWindowList(self):
-        return self.all_views + [self.specviz]
+        return self.cube_views + [self.specviz]
 
     def _setup_syncing(self):
         for attribute in ['x_min', 'x_max', 'y_min', 'y_max']:
@@ -677,7 +675,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         for view_index in [0, 1]:
             combo = self.get_viewer_combo(view_index)
             self._original_components[view_index] = combo.currentData()
-            view = self.all_views[view_index].widget()
+            view = self.cube_views[view_index].widget()
             self.change_viewer_component(view_index, component_id, force=True)
             view.set_smoothing_preview(preview_function, preview_title)
 
@@ -686,7 +684,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         End preview and change viewer combo index to the first component.
         """
         for view_index in [0, 1]:
-            view = self.all_views[view_index].widget()
+            view = self.cube_views[view_index].widget()
             view.end_smoothing_preview()
             if view_index in self._original_components:
                 component_id = self._original_components[view_index]

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -71,9 +71,9 @@ class CubevizManager(HubListener):
     def setup_data(self, cubeviz_layout, data):
         # Automatically add data to viewers and set attribute for split viewers
         image_viewers = [cubeviz_layout.single_view._widget,
-                         cubeviz_layout.left_view._widget,
-                         cubeviz_layout.middle_view._widget,
-                         cubeviz_layout.right_view._widget]
+                         cubeviz_layout.split_views[0]._widget,
+                         cubeviz_layout.split_views[1]._widget,
+                         cubeviz_layout.split_views[2]._widget]
 
         data_headers = [str(x).strip() for x in data.component_ids() if not x in data.coordinate_components]
 

--- a/cubeviz/tests/helpers.py
+++ b/cubeviz/tests/helpers.py
@@ -48,7 +48,7 @@ def assert_viewer_indices(viewer_array, index):
         assert viewer._widget.slice_index == index
 
 def assert_all_viewer_indices(layout, index):
-    assert_viewer_indices(layout.all_views, index)
+    assert_viewer_indices(layout.cube_views, index)
 
 def assert_wavelength_text(layout, text):
     assert layout._slice_controller._wavelength_textbox.text() == str(text)

--- a/cubeviz/tests/helpers.py
+++ b/cubeviz/tests/helpers.py
@@ -79,5 +79,5 @@ def reset_app_state(qtbot, layout):
     enter_slice_text(qtbot, layout, '1024')
     if layout._single_viewer_mode:
         toggle_viewer(qtbot, layout)
-    if layout._active_view is not layout.left_view:
-        select_viewer(qtbot, layout.left_view)
+    if layout._active_view is not layout.split_views[0]:
+        select_viewer(qtbot, layout.split_views[0])

--- a/cubeviz/tests/test_ui.py
+++ b/cubeviz/tests/test_ui.py
@@ -26,8 +26,8 @@ def test_starting_state(cubeviz_layout):
     assert cubeviz_layout.isVisible() == True
 
     assert cubeviz_layout._single_viewer_mode == False
-    assert cubeviz_layout._active_view is cubeviz_layout.left_view
-    assert cubeviz_layout._active_cube is cubeviz_layout.left_view
+    assert cubeviz_layout._active_view is cubeviz_layout.split_views[0]
+    assert cubeviz_layout._active_cube is cubeviz_layout.split_views[0]
 
     for viewer in cubeviz_layout.all_views:
         assert viewer._widget.synced == True
@@ -37,19 +37,19 @@ def assert_active_view_and_cube(layout, viewer):
     assert layout._active_cube is viewer
 
 def test_active_viewer(qtbot, cubeviz_layout):
-    select_viewer(qtbot, cubeviz_layout.middle_view)
-    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.middle_view)
+    select_viewer(qtbot, cubeviz_layout.split_views[1])
+    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.split_views[1])
 
-    select_viewer(qtbot, cubeviz_layout.right_view)
-    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.right_view)
+    select_viewer(qtbot, cubeviz_layout.split_views[2])
+    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.split_views[2])
 
     select_viewer(qtbot, cubeviz_layout.specviz)
     assert cubeviz_layout._active_view is cubeviz_layout.specviz
     # Selecting the specviz viewer should not affect the last active cube
-    assert cubeviz_layout._active_cube is cubeviz_layout.right_view
+    assert cubeviz_layout._active_cube is cubeviz_layout.split_views[2]
 
-    select_viewer(qtbot, cubeviz_layout.left_view)
-    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.left_view)
+    select_viewer(qtbot, cubeviz_layout.split_views[0])
+    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.split_views[0])
 
 def test_toggle_viewer_mode(qtbot, cubeviz_layout):
     toggle_viewer(qtbot, cubeviz_layout)
@@ -58,14 +58,14 @@ def test_toggle_viewer_mode(qtbot, cubeviz_layout):
 
     toggle_viewer(qtbot, cubeviz_layout)
     assert cubeviz_layout._single_viewer_mode == False
-    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.left_view)
+    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.split_views[0])
 
 def test_remember_active_viewer(qtbot, cubeviz_layout):
     """Make sure that the active viewer in the current layout is remembered"""
 
     # Change active viewer in the split mode viewer
-    select_viewer(qtbot, cubeviz_layout.right_view)
-    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.right_view)
+    select_viewer(qtbot, cubeviz_layout.split_views[2])
+    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.split_views[2])
 
     # Change to the single mode viewer
     toggle_viewer(qtbot, cubeviz_layout)
@@ -77,7 +77,7 @@ def test_remember_active_viewer(qtbot, cubeviz_layout):
 
     # Change back to the split mode viewer
     toggle_viewer(qtbot, cubeviz_layout)
-    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.right_view)
+    assert_active_view_and_cube(cubeviz_layout, cubeviz_layout.split_views[2])
 
     # Change back to the single mode viewer
     toggle_viewer(qtbot, cubeviz_layout)
@@ -204,29 +204,29 @@ def test_2d_data_components(qtbot, cubeviz_layout, moment_map, while_active):
     combo.setCurrentIndex(combo.findText(moment_map))
 
     assert_slider_enabled(cubeviz_layout, False)
-    assert cubeviz_layout.left_view._widget.has_2d_data == True
-    assert cubeviz_layout.left_view._widget.synced == False
+    assert cubeviz_layout.split_views[0]._widget.has_2d_data == True
+    assert cubeviz_layout.split_views[0]._widget.synced == False
 
     # Change the active viewer and make sure the slider is re-enabled
-    select_viewer(qtbot, cubeviz_layout.middle_view)
+    select_viewer(qtbot, cubeviz_layout.split_views[1])
     assert_slider_enabled(cubeviz_layout, True)
 
     enter_slice_text(qtbot, cubeviz_layout, 1234)
 
     # Change back to the left viewer currently displaying 2D data
     if while_active:
-        select_viewer(qtbot, cubeviz_layout.left_view)
-        assert cubeviz_layout.left_view._widget.has_2d_data == True
-        assert cubeviz_layout.left_view._widget.synced == False
+        select_viewer(qtbot, cubeviz_layout.split_views[0])
+        assert cubeviz_layout.split_views[0]._widget.has_2d_data == True
+        assert cubeviz_layout.split_views[0]._widget.synced == False
 
     # Return to displaying 3D data component
     combo.setCurrentIndex(combo.findText(DATA_LABELS[0]))
     assert_all_viewer_indices(cubeviz_layout, 1234)
-    assert cubeviz_layout.left_view._widget.has_2d_data == False
-    assert cubeviz_layout.left_view._widget.synced == True
+    assert cubeviz_layout.split_views[0]._widget.has_2d_data == False
+    assert cubeviz_layout.split_views[0]._widget.synced == True
 
     if not while_active:
-        select_viewer(qtbot, cubeviz_layout.left_view)
+        select_viewer(qtbot, cubeviz_layout.split_views[0])
         assert_slider_enabled(cubeviz_layout, True)
 
     assert_slider_enabled(cubeviz_layout, True)

--- a/cubeviz/tests/test_ui.py
+++ b/cubeviz/tests/test_ui.py
@@ -29,7 +29,7 @@ def test_starting_state(cubeviz_layout):
     assert cubeviz_layout._active_view is cubeviz_layout.split_views[0]
     assert cubeviz_layout._active_cube is cubeviz_layout.split_views[0]
 
-    for viewer in cubeviz_layout.all_views:
+    for viewer in cubeviz_layout.cube_views:
         assert viewer._widget.synced == True
 
 def assert_active_view_and_cube(layout, viewer):
@@ -95,7 +95,7 @@ def test_sync_checkboxes(qtbot, cubeviz_layout, viewer_index):
         toggle_viewer(qtbot, cubeviz_layout)
 
     checkbox = cubeviz_layout._synced_checkboxes[viewer_index]
-    viewer = cubeviz_layout.all_views[viewer_index]
+    viewer = cubeviz_layout.cube_views[viewer_index]
 
     left_click(qtbot, checkbox)
     assert viewer._widget.synced == False
@@ -134,7 +134,7 @@ def test_viewer_dropdowns(qtbot, cubeviz_layout, viewer_index):
         combo = getattr(cubeviz_layout.ui, 'viewer{0}_combo'.format(viewer_index))
         current_index = min(viewer_index - 1, 1) # only two datasets
 
-    widget = cubeviz_layout.all_views[viewer_index]._widget
+    widget = cubeviz_layout.cube_views[viewer_index]._widget
 
     # Make sure there are only two data components currently (dataset has two)
     assert combo.count() == 2
@@ -153,7 +153,7 @@ def test_add_data_component(qtbot, cubeviz_layout):
     for viewer_index in range(4):
         combo, current_index = setup_combo_and_index(
                                     qtbot, cubeviz_layout, viewer_index)
-        widget = cubeviz_layout.all_views[viewer_index]._widget
+        widget = cubeviz_layout.cube_views[viewer_index]._widget
 
         # Make sure the new index is there
         assert combo.count() == 3

--- a/cubeviz/tools/common.py
+++ b/cubeviz/tools/common.py
@@ -39,7 +39,7 @@ def add_to_2d_container(cubeviz_layout, data, component_data, label):
         for helper in cubeviz_layout._viewer_combo_helpers:
             helper.append_data(data.container_2d)
 
-        for viewer in cubeviz_layout.all_views:
+        for viewer in cubeviz_layout.cube_views:
             viewer._widget.add_data(data.container_2d)
 
     else:


### PR DESCRIPTION
This pays down some code debt and makes the split layout more general, allowing us to potentially support an arbitrary number of viewers in the future. We still retain the `single_viewer` named viewer since it is convenient to do so and does not cause any additional loss of generality.