### PR TITLE
Hide option sidebar when testing on Windows

### DIFF
--- a/cubeviz/conftest.py
+++ b/cubeviz/conftest.py
@@ -1,6 +1,8 @@
 # This file is used to configure the behavior of pytest when using the Astropy
 # test infrastructure.
 
+import sys
+
 from astropy.version import version as astropy_version
 if astropy_version < '3.0':
     # With older versions of Astropy, we actually need to import the pytest
@@ -66,6 +68,12 @@ from .tests.helpers import (toggle_viewer, select_viewer, create_glue_app,
 @pytest.fixture(scope='session')
 def cubeviz_layout():
     app = create_glue_app()
+    layout = app.tab(0)
+
+    # Cheap workaround for Windows test environment
+    if sys.platform.startswith('win'):
+        layout._cubeviz_toolbar._toggle_sidebar()
+
     return app.tab(0)
 
 @pytest.fixture(autouse=True)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -62,10 +62,12 @@ class CubeVizLayout(QtWidgets.QWidget):
     def __init__(self, session=None, parent=None):
         super(CubeVizLayout, self).__init__(parent=parent)
 
+        self._cubeviz_toolbar = None
+
         if not hasattr(session.application, '_has_cubeviz_toolbar'):
-            cubeviz_toolbar = CubevizToolbar(application=session.application)
+            self._cubeviz_toolbar = CubevizToolbar(application=session.application)
             session.application.insertToolBar(session.application._data_toolbar,
-                                              cubeviz_toolbar)
+                                              self._cubeviz_toolbar)
 
         self.session = session
         self._has_data = False


### PR DESCRIPTION
Having the sidebar present by default seems to cause test failures on Windows for somewhat mysterious reasons.  Hopefully this fix will allow tests to pass.

This fixes #306.