### PR TITLE
Display ROI/subset stats

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -191,6 +191,8 @@ class CubevizImageViewer(ImageViewer):
         self._toggle_3d = False  # True if we just toggled from 2D to 3D
 
         self._stats_axes = None
+        self._stats_visible = True  # Global configuration setting
+        self._stats_hidden = False  # Internal configuration: are stats hidden?
         self._component = None # Keep track of name of currently displayed component
         self._subset = None # Keep track of currently active subset
 
@@ -262,13 +264,15 @@ class CubevizImageViewer(ImageViewer):
             circle = self._stats_axes.artists[0]
             circle.set_color(subset.style.color)
             self._update_stats_text(mu, sigma)
-            self._stats_axes.set_visible(True)
+            self._stats_axes.set_visible(True and self._stats_visible)
 
+        self._stats_hidden = False
         self.redraw()
 
     def hide_stats_axes(self):
         if self._stats_axes is not None:
             self._stats_axes.set_visible(False)
+            self._stats_hidden = True
             self.redraw()
 
     def update_stats(self):
@@ -282,6 +286,12 @@ class CubevizImageViewer(ImageViewer):
         self._component = component
         if self._stats_axes is not None:
             self.update_stats()
+
+    def set_stats_visible(self, visible):
+        self._stats_visible = visible
+        if self._stats_axes is not None:
+            self._stats_axes.set_visible(self._stats_visible and not self._stats_hidden)
+            self.redraw()
 
     @property
     def is_preview_active(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -223,10 +223,10 @@ class CubevizImageViewer(ImageViewer):
             cls = CubevizImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
-    def _create_stats_axes(self):
+    def _create_stats_axes(self, subset):
         rect = 0.01, 0.88, 0.15, 0.12
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
-        circle = Circle((0.15,0.85), 0.05, color='r')
+        circle = Circle((0.15,0.85), 0.05, color=subset.style.color)
         axes.add_artist(circle)
 
         text_opts = dict(x=0.05, size='smaller')
@@ -235,10 +235,16 @@ class CubevizImageViewer(ImageViewer):
         axes.text(**text_opts, y=0.05, s=r'$\sigma = 0.10$')
         return axes
 
-    def draw_stats_axes(self):
+    def _update_stats_axes(self, subset):
+        # TODO: we should probably stash a pointer to this in the long term
+        circle = self._stats_axes.artists[0]
+        circle.set_color(subset.style.color)
+
+    def draw_stats_axes(self, subset):
         if self._stats_axes is None:
-            self._stats_axes = self._create_stats_axes()
+            self._stats_axes = self._create_stats_axes(subset)
         else:
+            self._update_stats_axes(subset)
             self._stats_axes.set_visible(True)
 
         self.redraw()

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -223,7 +223,7 @@ class CubevizImageViewer(ImageViewer):
             cls = CubevizImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
-    def _create_stats_axes(self, subset):
+    def _create_stats_axes(self, subset, mu, sigma):
         rect = 0.01, 0.88, 0.15, 0.12
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
         circle = Circle((0.15,0.85), 0.05, color=subset.style.color)
@@ -231,14 +231,15 @@ class CubevizImageViewer(ImageViewer):
 
         text_opts = dict(x=0.05, size='smaller')
         axes.text(**text_opts, y=0.55, s='slice: {}'.format(self._slice_index))
-        axes.text(**text_opts, y=0.30, s=r'$\mu = 0.15$')
-        axes.text(**text_opts, y=0.05, s=r'$\sigma = 0.10$')
+        axes.text(**text_opts, y=0.30, s=r'$\mu = {:.3}$'.format(mu))
+        axes.text(**text_opts, y=0.05, s=r'$\sigma = {:.3}$'.format(sigma))
         return axes
 
-    def _update_stats_axes(self, subset):
-        # TODO: we should probably stash a pointer to this in the long term
-        circle = self._stats_axes.artists[0]
-        circle.set_color(subset.style.color)
+    def _update_stats_text(self, mu, sigma):
+        mu_text = self._stats_axes.texts[1]
+        mu_text.set_text(r'$\mu = {:.3}$'.format(mu))
+        sigma_text = self._stats_axes.texts[2]
+        sigma_text.set_text(r'$\sigma = {:.3}$'.format(sigma))
 
     def _calculate_stats(self, component, subset):
         mask = subset.to_mask()[self._slice_index]
@@ -247,12 +248,14 @@ class CubevizImageViewer(ImageViewer):
 
     def draw_stats_axes(self, component, subset):
         mu, sigma = self._calculate_stats(component, subset)
-        print(component, mu, sigma)
 
         if self._stats_axes is None:
-            self._stats_axes = self._create_stats_axes(subset)
+            self._stats_axes = self._create_stats_axes(subset, mu, sigma)
         else:
-            self._update_stats_axes(subset)
+            # TODO: we should probably stash a pointer to this in the long term
+            circle = self._stats_axes.artists[0]
+            circle.set_color(subset.style.color)
+            self._update_stats_text(mu, sigma)
             self._stats_axes.set_visible(True)
 
         self.redraw()

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -191,6 +191,8 @@ class CubevizImageViewer(ImageViewer):
         self._toggle_3d = False  # True if we just toggled from 2D to 3D
 
         self._stats_axes = None
+        self._component = None # Keep track of name of currently displayed component
+        self._subset = None # Keep track of currently active subset
 
         self.coord_label = QLabel("")  # Coord display
         self.statusBar().addPermanentWidget(self.coord_label)
@@ -247,6 +249,10 @@ class CubevizImageViewer(ImageViewer):
         return data.mean(), data.std()
 
     def draw_stats_axes(self, component, subset):
+
+        self._component = component
+        self._subset = subset
+
         mu, sigma = self._calculate_stats(component, subset)
 
         if self._stats_axes is None:
@@ -268,6 +274,8 @@ class CubevizImageViewer(ImageViewer):
     def update_stats(self):
         slice_text = self._stats_axes.texts[0]
         slice_text.set_text('slice: {}'.format(self._slice_index))
+        mu, sigma = self._calculate_stats(self._component, self._subset)
+        self._update_stats_text(mu, sigma)
 
     @property
     def is_preview_active(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -240,7 +240,15 @@ class CubevizImageViewer(ImageViewer):
         circle = self._stats_axes.artists[0]
         circle.set_color(subset.style.color)
 
-    def draw_stats_axes(self, subset):
+    def _calculate_stats(self, component, subset):
+        mask = subset.to_mask()[self._slice_index]
+        data = self._data[0][component][self._slice_index][mask]
+        return data.mean(), data.std()
+
+    def draw_stats_axes(self, component, subset):
+        mu, sigma = self._calculate_stats(component, subset)
+        print(component, mu, sigma)
+
         if self._stats_axes is None:
             self._stats_axes = self._create_stats_axes(subset)
         else:

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -203,7 +203,6 @@ class CubevizImageViewer(ImageViewer):
         # Allow the CubeViz slider to respond to viewer-specific sliders in the glue pane
         self.state.add_callback('slices', self._slice_callback)
 
-        self.draw_stats_axes()
 
     def _slice_callback(self, new_slice):
         if self._slice_index is not None and not self.has_2d_data:

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from matplotlib.axes import Axes
 import matplotlib.image as mimage
+from matplotlib.patches import Circle
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -225,9 +226,11 @@ class CubevizImageViewer(ImageViewer):
     def _create_stats_axes(self):
         rect = 0.01, 0.88, 0.12, 0.10
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
-        axes.text(x=0.05, y=0.75, s='slice: {}'.format(self._slice_index))
-        axes.text(x=0.05, y=0.50, s=r'$\mu = 0.15$')
-        axes.text(x=0.05, y=0.25, s=r'$\sigma = 0.10$')
+        circle = Circle((0.15,0.85), 0.05, color='r')
+        axes.add_artist(circle)
+        axes.text(x=0.05, y=0.55, s='slice: {}'.format(self._slice_index))
+        axes.text(x=0.05, y=0.30, s=r'$\mu = 0.15$')
+        axes.text(x=0.05, y=0.05, s=r'$\sigma = 0.10$')
         return axes
 
     def draw_stats_axes(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -276,6 +276,12 @@ class CubevizImageViewer(ImageViewer):
         slice_text.set_text('slice: {}'.format(self._slice_index))
         mu, sigma = self._calculate_stats(self._component, self._subset)
         self._update_stats_text(mu, sigma)
+        self.redraw()
+
+    def update_component(self, component):
+        self._component = component
+        if self._stats_axes is not None:
+            self.update_stats()
 
     @property
     def is_preview_active(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 
+from matplotlib.axes import Axes
 import matplotlib.image as mimage
 
 from astropy import units as u
@@ -202,6 +203,8 @@ class CubevizImageViewer(ImageViewer):
         # Allow the CubeViz slider to respond to viewer-specific sliders in the glue pane
         self.state.add_callback('slices', self._slice_callback)
 
+        self.draw_stats_axes()
+
     def _slice_callback(self, new_slice):
         if self._slice_index is not None and not self.has_2d_data:
             self.cubeviz_layout._slice_controller.update_index(new_slice[0])
@@ -217,6 +220,14 @@ class CubevizImageViewer(ImageViewer):
         else:
             cls = CubevizImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+
+    def draw_stats_axes(self):
+        rect = 0.01, 0.88, 0.12, 0.10
+        axes = self.figure.add_axes(rect, xticks=[], yticks=[])
+        axes.text(x=0.05, y=0.75, s='slice: {}'.format(self._slice_index))
+        axes.text(x=0.05, y=0.50, s=r'$\mu = 0.15$')
+        axes.text(x=0.05, y=0.25, s=r'$\sigma = 0.10$')
+        self.redraw()
 
     @property
     def is_preview_active(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -224,13 +224,15 @@ class CubevizImageViewer(ImageViewer):
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
     def _create_stats_axes(self):
-        rect = 0.01, 0.88, 0.12, 0.10
+        rect = 0.01, 0.88, 0.15, 0.12
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
         circle = Circle((0.15,0.85), 0.05, color='r')
         axes.add_artist(circle)
-        axes.text(x=0.05, y=0.55, s='slice: {}'.format(self._slice_index))
-        axes.text(x=0.05, y=0.30, s=r'$\mu = 0.15$')
-        axes.text(x=0.05, y=0.05, s=r'$\sigma = 0.10$')
+
+        text_opts = dict(x=0.05, size='smaller')
+        axes.text(**text_opts, y=0.55, s='slice: {}'.format(self._slice_index))
+        axes.text(**text_opts, y=0.30, s=r'$\mu = 0.15$')
+        axes.text(**text_opts, y=0.05, s=r'$\sigma = 0.10$')
         return axes
 
     def draw_stats_axes(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -189,6 +189,8 @@ class CubevizImageViewer(ImageViewer):
         self._has_2d_data = False  # True if currently displayed data is 2D
         self._toggle_3d = False  # True if we just toggled from 2D to 3D
 
+        self._stats_axes = None
+
         self.coord_label = QLabel("")  # Coord display
         self.statusBar().addPermanentWidget(self.coord_label)
 
@@ -220,13 +222,26 @@ class CubevizImageViewer(ImageViewer):
             cls = CubevizImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
-    def draw_stats_axes(self):
+    def _create_stats_axes(self):
         rect = 0.01, 0.88, 0.12, 0.10
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
         axes.text(x=0.05, y=0.75, s='slice: {}'.format(self._slice_index))
         axes.text(x=0.05, y=0.50, s=r'$\mu = 0.15$')
         axes.text(x=0.05, y=0.25, s=r'$\sigma = 0.10$')
+        return axes
+
+    def draw_stats_axes(self):
+        if self._stats_axes is None:
+            self._stats_axes = self._create_stats_axes()
+        else:
+            self._stats_axes.set_visible(True)
+
         self.redraw()
+
+    def hide_stats_axes(self):
+        if self._stats_axes is not None:
+            self._stats_axes.set_visible(False)
+            self.redraw()
 
     @property
     def is_preview_active(self):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -243,6 +243,10 @@ class CubevizImageViewer(ImageViewer):
             self._stats_axes.set_visible(False)
             self.redraw()
 
+    def update_stats(self):
+        slice_text = self._stats_axes.texts[0]
+        slice_text.set_text('slice: {}'.format(self._slice_index))
+
     @property
     def is_preview_active(self):
         return self.is_contour_preview_active or self.is_smoothing_preview_active
@@ -540,6 +544,9 @@ class CubevizImageViewer(ImageViewer):
         self.state.slices = (self._slice_index, y, x)
         if self.is_contour_active:
             self.draw_contour()
+
+        if self._stats_axes is not None:
+            self.update_stats()
 
     def fast_draw_slice_at_index(self, index):
         """

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -232,6 +232,10 @@ class CubeVizLayout(QtWidgets.QWidget):
         if isinstance(message, SettingsChangeMessage):
             self._slice_controller.update_index(self.synced_index)
 
+    def handle_subset_action(self, message):
+        for viewer in self.cube_views:
+            viewer._widget.draw_stats_axes()
+
     def _set_pos_and_margin(self, axes, pos, marg):
         axes.set_position(pos)
         freeze_margins(axes, marg)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -234,8 +234,8 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def handle_subset_action(self, message):
         if message.subset:
-            for viewer in self.cube_views:
-                viewer._widget.draw_stats_axes(message.subset[0].subsets[0])
+            for combo, viewer in zip(self._viewer_combo_helpers, self.cube_views):
+                viewer._widget.draw_stats_axes(combo.selection, message.subset[0].subsets[0])
         else:
             for viewer in self.cube_views:
                 viewer._widget.hide_stats_axes()

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -228,7 +228,7 @@ class CubeVizLayout(QtWidgets.QWidget):
                 menu_widget.addAction(act)
         return menu_widget
 
-    def _handle_settings_change(self, message):
+    def handle_settings_change(self, message):
         if isinstance(message, SettingsChangeMessage):
             self._slice_controller.update_index(self.synced_index)
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -410,6 +410,8 @@ class CubeVizLayout(QtWidgets.QWidget):
             if viewer.is_contour_active:
                 viewer.draw_contour()
 
+            viewer.update_component(component)
+
         return _on_viewer_combo_change
 
     def _enable_viewer_combo(self, data, index, combo_label, selection_label):

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -233,8 +233,12 @@ class CubeVizLayout(QtWidgets.QWidget):
             self._slice_controller.update_index(self.synced_index)
 
     def handle_subset_action(self, message):
-        for viewer in self.cube_views:
-            viewer._widget.draw_stats_axes()
+        if message.subset:
+            for viewer in self.cube_views:
+                viewer._widget.draw_stats_axes()
+        else:
+            for viewer in self.cube_views:
+                viewer._widget.hide_stats_axes()
 
     def _set_pos_and_margin(self, axes, pos, marg):
         axes.set_position(pos)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -235,7 +235,7 @@ class CubeVizLayout(QtWidgets.QWidget):
     def handle_subset_action(self, message):
         if message.subset:
             for viewer in self.cube_views:
-                viewer._widget.draw_stats_axes()
+                viewer._widget.draw_stats_axes(message.subset[0].subsets[0])
         else:
             for viewer in self.cube_views:
                 viewer._widget.hide_stats_axes()

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -13,7 +13,7 @@ from glue.config import qt_fixed_layout_tab
 from glue.external.echo import keep_in_sync, SelectionCallbackProperty
 from glue.external.echo.qt import connect_combo_selection
 from glue.core.data_combo_helper import ComponentIDComboHelper
-from glue.core.message import SettingsChangeMessage
+from glue.core.message import SettingsChangeMessage, SubsetUpdateMessage, SubsetDeleteMessage
 from glue.utils.matplotlib import freeze_margins
 
 from specviz.third_party.glue.data_viewer import SpecVizViewer
@@ -233,10 +233,10 @@ class CubeVizLayout(QtWidgets.QWidget):
             self._slice_controller.update_index(self.synced_index)
 
     def handle_subset_action(self, message):
-        if message.subset:
+        if isinstance(message, SubsetUpdateMessage):
             for combo, viewer in zip(self._viewer_combo_helpers, self.cube_views):
-                viewer._widget.draw_stats_axes(combo.selection, message.subset[0].subsets[0])
-        else:
+                viewer._widget.draw_stats_axes(combo.selection, message.subset)
+        elif isinstance(message, SubsetDeleteMessage):
             for viewer in self.cube_views:
                 viewer._widget.hide_stats_axes()
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -133,6 +133,9 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Indicates whether cube viewer toolbars are currently visible or not
         self._toolbars_visible = True
 
+        # Indicates whether subset stats should be displayed or not
+        self._stats_visible = True
+
         self._slice_controller = SliceController(self)
         self._overlay_controller = OverlayController(self)
         self._units_controller = UnitController(self)
@@ -179,6 +182,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         view_menu = self._dict_to_menu(OrderedDict([
             ('Hide Axes', ['checkable', self._toggle_viewer_axes]),
             ('Hide Toolbars', ['checkable', self._toggle_toolbars]),
+            ('Hide Stats', ['checkable', self._toggle_stats_display]),
             ('Wavelength Units', lambda: self._open_dialog('Wavelength Units', None))
         ]))
 
@@ -271,6 +275,11 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._toolbars_visible = not self._toolbars_visible
         for viewer in self.cube_views:
             viewer._widget.toolbar.setVisible(self._toolbars_visible)
+
+    def _toggle_stats_display(self):
+        self._stats_visible = not self._stats_visible
+        for viewer in self.cube_views:
+            viewer._widget.set_stats_visible(self._stats_visible)
 
     def _open_dialog(self, name, widget):
 

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from glue.core import Hub, HubListener, Data, DataCollection
-from glue.core.message import (DataCollectionAddMessage, DataRemoveComponentMessage,
-                               DataAddComponentMessage, SettingsChangeMessage)
+from glue.core.message import (DataCollectionAddMessage, SettingsChangeMessage,
+                               DataRemoveComponentMessage, EditSubsetMessage,
+                               DataAddComponentMessage)
 from .layout import CubeVizLayout
 
 
@@ -31,6 +32,8 @@ class CubevizManager(HubListener):
             self, SettingsChangeMessage, handler=self.handle_settings_change)
         self._hub.subscribe(
             self, DataRemoveComponentMessage, handler=self.handle_remove_component)
+        self._hub.subscribe(
+            self, EditSubsetMessage, handler=self.handle_subset_message)
 
         # Look for any cube data files that were loaded from the command line
         for data in session.data_collection:
@@ -64,6 +67,10 @@ class CubevizManager(HubListener):
     def handle_settings_change(self, message):
         if self._layout is not None:
             self._layout.handle_settings_change(message)
+
+    def handle_subset_message(self, message):
+        if self._layout is not None:
+            self._layout.handle_subset_action(message)
 
     def hide_sidebar(self):
         self._app._ui.main_splitter.setSizes([0, 300])

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -2,7 +2,7 @@
 
 from glue.core import Hub, HubListener, Data, DataCollection
 from glue.core.message import (DataCollectionAddMessage, SettingsChangeMessage,
-                               DataRemoveComponentMessage, EditSubsetMessage,
+                               DataRemoveComponentMessage, SubsetMessage,
                                DataAddComponentMessage)
 from .layout import CubeVizLayout
 
@@ -33,7 +33,7 @@ class CubevizManager(HubListener):
         self._hub.subscribe(
             self, DataRemoveComponentMessage, handler=self.handle_remove_component)
         self._hub.subscribe(
-            self, EditSubsetMessage, handler=self.handle_subset_message)
+            self, SubsetMessage, handler=self.handle_subset_message)
 
         # Look for any cube data files that were loaded from the command line
         for data in session.data_collection:

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -63,7 +63,7 @@ class CubevizManager(HubListener):
 
     def handle_settings_change(self, message):
         if self._layout is not None:
-            self._layout._handle_settings_change(message)
+            self._layout.handle_settings_change(message)
 
     def hide_sidebar(self):
         self._app._ui.main_splitter.setSizes([0, 300])


### PR DESCRIPTION
This PR introduces a feature that displays basic statistics about selected ROIs in the viewer:

![image](https://user-images.githubusercontent.com/2458487/37486158-09272624-2864-11e8-9989-7cecd2640ca5.png)

Currently the stats include mean and standard deviation of the flux values under the selected region for the current slice. If it is useful to do so, the stats could include mean and standard deviation of flux values through the entire cube under the selected region.

This also adds a top-level configuration option that determines whether the stats should be displayed or not:

![image](https://user-images.githubusercontent.com/2458487/37486225-42537dda-2864-11e8-9268-410ab485226a.png)

Currently no units are displayed. This would probably be a useful addition, but unfortunately there is limited real estate.

Comments and suggestions are welcome.