### PR TITLE
Do not automatically display overlays

### DIFF
--- a/cubeviz/controls/overlay.py
+++ b/cubeviz/controls/overlay.py
@@ -35,7 +35,7 @@ class OverlayController:
 
         self._alpha_slider.valueChanged.connect(self._on_alpha_change)
 
-    def add_overlay(self, data, label):
+    def add_overlay(self, data, label, display=True):
         self._overlays.add_component(data, label)
         # TODO: Is there a way to get this from the component ???
         self._overlay_image_combo.addItem(label)
@@ -46,8 +46,9 @@ class OverlayController:
         self._overlay_image_combo.setEnabled(True)
         self._overlay_colormap_combo.setEnabled(True)
 
-        # Setting the index will cause _on_overlay_change to fire
-        self._overlay_image_combo.setCurrentIndex(new_index)
+        if display:
+            # Setting the index will cause _on_overlay_change to fire
+            self._overlay_image_combo.setCurrentIndex(new_index)
 
     def _on_overlay_change(self, index):
         if index == 0:

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -326,7 +326,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         operation_handler.exec_()
 
     def add_new_data_component(self, component_id):
-        self.update_active_view(component_id)
+        self.display_component(component_id)
 
     def remove_data_component(self, component_id):
         pass
@@ -454,12 +454,12 @@ class CubeVizLayout(QtWidgets.QWidget):
         else:
             combo.setCurrentIndex(component_index)
 
-    def update_active_view(self, component_id):
-        self.refresh_viewer_combo_helpers()
-
-        if self._active_view in self.cube_views:
-            view_index = self.cube_views.index(self._active_view)
-            self.change_viewer_component(view_index, component_id)
+    def display_component(self, component_id):
+        """
+        Displays data with given component ID in the active cube viewer.
+        """
+        view_index = self.cube_views.index(self._active_cube)
+        self.change_viewer_component(view_index, component_id)
 
     def get_viewer_combo(self, view_index):
         """
@@ -473,7 +473,7 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def add_overlay(self, data, label, display_now=True):
         self._overlay_controller.add_overlay(data, label, display=display_now)
-        self.update_active_view(label)
+        self.display_component(label)
 
     def _set_data_coord_system(self, data):
         """

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -466,8 +466,8 @@ class CubeVizLayout(QtWidgets.QWidget):
             combo_label = 'viewer{0}_combo'.format(view_index)
         return getattr(self.ui, combo_label)
 
-    def add_overlay(self, data, label):
-        self._overlay_controller.add_overlay(data, label)
+    def add_overlay(self, data, label, display_now=True):
+        self._overlay_controller.add_overlay(data, label, display=display_now)
 
     def _set_data_coord_system(self, data):
         """

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -326,12 +326,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         operation_handler.exec_()
 
     def add_new_data_component(self, component_id):
-
-        self.refresh_viewer_combo_helpers()
-
-        if self._active_view in self.cube_views:
-            view_index = self.cube_views.index(self._active_view)
-            self.change_viewer_component(view_index, component_id)
+        self.update_active_view(component_id)
 
     def remove_data_component(self, component_id):
         pass
@@ -449,12 +444,22 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         combo = self.get_viewer_combo(view_index)
 
-        component_index = combo.findData(component_id)
+        if isinstance(component_id, str):
+            component_index = combo.findText(component_id)
+        else:
+            component_index = combo.findData(component_id)
 
         if combo.currentIndex() == component_index and force:
             combo.currentIndexChanged.emit(component_index)
         else:
             combo.setCurrentIndex(component_index)
+
+    def update_active_view(self, component_id):
+        self.refresh_viewer_combo_helpers()
+
+        if self._active_view in self.cube_views:
+            view_index = self.cube_views.index(self._active_view)
+            self.change_viewer_component(view_index, component_id)
 
     def get_viewer_combo(self, view_index):
         """
@@ -468,6 +473,7 @@ class CubeVizLayout(QtWidgets.QWidget):
 
     def add_overlay(self, data, label, display_now=True):
         self._overlay_controller.add_overlay(data, label, display=display_now)
+        self.update_active_view(label)
 
     def _set_data_coord_system(self, data):
         """

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -455,6 +455,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         """
         Displays data with given component ID in the active cube viewer.
         """
+        self.refresh_viewer_combo_helpers()
         view_index = self.cube_views.index(self._active_cube)
         self.change_viewer_component(view_index, component_id)
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -325,9 +325,6 @@ class CubeVizLayout(QtWidgets.QWidget):
                                                      parent=self)
         operation_handler.exec_()
 
-    def add_new_data_component(self, component_id):
-        self.display_component(component_id)
-
     def remove_data_component(self, component_id):
         pass
 

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -55,8 +55,7 @@ class CubevizManager(HubListener):
             self._empty_layout = None
 
     def handle_new_component(self, message):
-        #self._layout.add_new_data_component(str(message.component_id))
-        self._layout.add_new_data_component(message.component_id)
+        self._layout.display_component(message.component_id)
 
     def handle_remove_component(self, message):
         self._layout.remove_data_component(message.component_id)

--- a/cubeviz/tests/test_ui.py
+++ b/cubeviz/tests/test_ui.py
@@ -198,10 +198,13 @@ def test_2d_data_components(qtbot, cubeviz_layout, moment_map, while_active):
 
     assert moment_map == DATA_LABELS[0] + '-moment-1'
 
-    assert_slider_enabled(cubeviz_layout, True)
-
     combo, _ = setup_combo_and_index(qtbot, cubeviz_layout, 1)
-    combo.setCurrentIndex(combo.findText(moment_map))
+
+    # For the first test, the active viewer should now display a 2D moment map,
+    # so no action is required.
+    if not while_active:
+        select_viewer(qtbot, cubeviz_layout.split_views[0])
+        combo.setCurrentIndex(combo.findText(moment_map))
 
     assert_slider_enabled(cubeviz_layout, False)
     assert cubeviz_layout.split_views[0]._widget.has_2d_data == True

--- a/cubeviz/tools/collapse_cube.py
+++ b/cubeviz/tools/collapse_cube.py
@@ -507,7 +507,7 @@ class CollapseCube(QDialog):
         # container Data object and also as an overlay. In future we might be
         # able to use the 2D container Data object for the overlays directly.
         add_to_2d_container(self.parent, self.data, new_component, label)
-        self.parent.add_overlay(new_component, label)
+        self.parent.add_overlay(new_component, label, display_now=False)
 
         self.close()
 

--- a/cubeviz/tools/moment_maps.py
+++ b/cubeviz/tools/moment_maps.py
@@ -101,7 +101,7 @@ class MomentMapsGUI(QDialog):
             # container Data object and also as an overlay. In future we might be
             # able to use the 2D container Data object for the overlays directly.
             add_to_2d_container(self.parent, self.data, cube_moment.value, self.label)
-            self.parent.add_overlay(cube_moment.value, self.label)
+            self.parent.add_overlay(cube_moment.value, self.label, display_now=False)
 
         except Exception as e:
             print('Error {}'.format(e))


### PR DESCRIPTION
With this PR, overlays resulting from moment maps and collapsed cubes are no longer displayed automatically. Instead, the last active cube viewer is automatically populated with the result of the computation.

This fixes #309.