### PR TITLE
Add median to ROI stats

### DIFF
--- a/cubeviz/controls/slice.py
+++ b/cubeviz/controls/slice.py
@@ -185,6 +185,7 @@ class SliceController(HubListener):
         self._slider_flag = False
 
         index = self._slice_slider.value()
+        self._send_index_message(index)
         specviz_dispatch.changed_dispersion_position.emit(pos=index)
 
     #@glue_subscribe(SliceIndexUpdateMessage)

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -246,22 +246,25 @@ class CubevizImageViewer(ImageViewer, HubListener):
             cls = CubevizImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
-    def _create_stats_axes(self, subset, mu, sigma):
-        rect = 0.01, 0.88, 0.15, 0.12
+    def _create_stats_axes(self, subset, median, mu, sigma):
+        rect = 0.01, 0.84, 0.20, 0.12
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
         circle = Circle((0.15,0.85), 0.05, color=subset.style.color)
         axes.add_artist(circle)
 
         text_opts = dict(x=0.05, size='smaller')
-        axes.text(**text_opts, y=0.55, s='slice: {}'.format(self._slice_index))
-        axes.text(**text_opts, y=0.30, s=r'$\mu = {:.3}$'.format(mu))
-        axes.text(**text_opts, y=0.05, s=r'$\sigma = {:.3}$'.format(sigma))
+        axes.text(size='smaller', x=0.35, y=0.75, s='slice: {}'.format(self._slice_index))
+        axes.text(**text_opts, y=0.52, s=r'$\widetilde{{x}} = {:.3}$'.format(median))
+        axes.text(**text_opts, y=0.28, s=r'$\mu = {:.3}$'.format(mu))
+        axes.text(**text_opts, y=0.02, s=r'$\sigma = {:.3}$'.format(sigma))
         return axes
 
-    def _update_stats_text(self, mu, sigma):
-        mu_text = self._stats_axes.texts[1]
+    def _update_stats_text(self, median, mu, sigma):
+        median_text = self._stats_axes.texts[1]
+        median_text.set_text(r'$\widetilde{{x}} = {:.3}$'.format(median))
+        mu_text = self._stats_axes.texts[2]
         mu_text.set_text(r'$\mu = {:.3}$'.format(mu))
-        sigma_text = self._stats_axes.texts[2]
+        sigma_text = self._stats_axes.texts[3]
         sigma_text.set_text(r'$\sigma = {:.3}$'.format(sigma))
 
     def _calculate_stats(self, component, subset):
@@ -270,22 +273,22 @@ class CubevizImageViewer(ImageViewer, HubListener):
         if self.cubeviz_unit is not None:
             wave = self.cubeviz_layout.get_wavelength(self.slice_index)
             data = self.cubeviz_unit.convert_from_original_unit(data, wave=wave)
-        return data.mean(), data.std()
+        return np.median(data), data.mean(), data.std()
 
     def draw_stats_axes(self, component, subset):
 
         self._component = component
         self._subset = subset
 
-        mu, sigma = self._calculate_stats(component, subset)
+        median, mu, sigma = self._calculate_stats(component, subset)
 
         if self._stats_axes is None:
-            self._stats_axes = self._create_stats_axes(subset, mu, sigma)
+            self._stats_axes = self._create_stats_axes(subset, median, mu, sigma)
         else:
             # TODO: we should probably stash a pointer to this in the long term
             circle = self._stats_axes.artists[0]
             circle.set_color(subset.style.color)
-            self._update_stats_text(mu, sigma)
+            self._update_stats_text(median, mu, sigma)
             self._stats_axes.set_visible(True and self._stats_visible)
 
         self._stats_hidden = False

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -247,7 +247,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
     def _create_stats_axes(self, subset, median, mu, sigma):
-        rect = 0.01, 0.84, 0.20, 0.12
+        rect = 0.01, 0.87, 0.20, 0.12
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
         circle = Circle((0.15,0.85), 0.05, color=subset.style.color)
         axes.add_artist(circle)
@@ -303,8 +303,8 @@ class CubevizImageViewer(ImageViewer, HubListener):
     def update_stats(self):
         slice_text = self._stats_axes.texts[0]
         slice_text.set_text('slice: {}'.format(self._slice_index))
-        mu, sigma = self._calculate_stats(self._component, self._subset)
-        self._update_stats_text(mu, sigma)
+        median, mu, sigma = self._calculate_stats(self._component, self._subset)
+        self._update_stats_text(median, mu, sigma)
         self.redraw()
 
     def update_component(self, component):


### PR DESCRIPTION
This resolves #321. It also fixes a bug that was introduced by #343 that causes the wrong ROI stats to be displayed when the slider is released.