### PR TITLE
changed description to include parameters of smoothing

### DIFF
--- a/cubeviz/tools/spectral_operations.py
+++ b/cubeviz/tools/spectral_operations.py
@@ -164,8 +164,8 @@ class SpectralOperationHandler(QDialog):
 
             super(SpectralOperationHandler, self).accept()
 
-        component_name = "{} {}".format(self.component_id,
-                                        self.function.function.__name__)
+        component_name = '{} spectral {}'.format(self.component_id, 
+                self.operation_combo_box.currentText())
 
         comp_count = len([x for x in self.data.component_ids()
                           if component_name in str(x)])

--- a/cubeviz/tools/spectral_operations.py
+++ b/cubeviz/tools/spectral_operations.py
@@ -164,7 +164,7 @@ class SpectralOperationHandler(QDialog):
 
             super(SpectralOperationHandler, self).accept()
 
-        component_name = '{} spectral {}'.format(self.component_id, 
+        component_name = '{} spectral {}'.format(self.component_id,
                 self.operation_combo_box.currentText())
 
         comp_count = len([x for x in self.data.component_ids()


### PR DESCRIPTION
I changed the spectral smoothing description to include parameters of the smoothing.  So it now looks like:
![image](https://user-images.githubusercontent.com/18348847/38372600-3b2375d8-38bd-11e8-8588-5fc7c77f8cb0.png)

(previously it just said "Flux Smooth".

This fixes https://github.com/spacetelescope/cubeviz/issues/235.