### PR TITLE
Prevent creation of duplicate moment maps and collapsed cubes

### DIFF
--- a/cubeviz/tools/collapse_cube.py
+++ b/cubeviz/tools/collapse_cube.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import (QDialog, QApplication, QPushButton, QLabel, QWidget,
 
 from astropy.stats import sigma_clip
 
-from .common import add_to_2d_container
+from .common import add_to_2d_container, show_error_message
 
 # The operations we understand
 operations = {
@@ -509,13 +509,20 @@ class CollapseCube(QDialog):
         # Add new overlay/component to cubeviz. We add this both to the 2D
         # container Data object and also as an overlay. In future we might be
         # able to use the 2D container Data object for the overlays directly.
-        add_to_2d_container(self.parent, self.data, new_component, label)
-        self.parent.add_overlay(new_component, label, display_now=False)
 
-        self.close()
+        try:
+            add_to_2d_container(self.parent, self.data, new_component, label)
+            self.parent.add_overlay(new_component, label, display_now=False)
+        except Exception as e:
+            print('Error: {}'.format(e))
+            show_error_message(str(e), 'Collapse Cube Error', parent=self)
+            return
+        finally:
+            self.close()
 
         # Show new dialog
         self.final_dialog(label)
+
 
     def final_dialog(self, label):
         """

--- a/cubeviz/tools/common.py
+++ b/cubeviz/tools/common.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from qtpy.QtWidgets import QMessageBox
+
 from glue.core import Data
 from glue.core.link_helpers import LinkSame
 from glue.core.coordinates import WCSCoordinates
@@ -43,5 +45,18 @@ def add_to_2d_container(cubeviz_layout, data, component_data, label):
             viewer._widget.add_data(data.container_2d)
 
     else:
+        # Make sure we don't add duplicate data components
+        if label in data.container_2d.component_ids():
+            raise ValueError("Data component with label '{}' already exists, "
+                             "and cannot be created again".format(label))
 
         data.container_2d.add_component(component_data, label)
+
+def show_error_message(message, title, parent=None):
+
+    box = QMessageBox(parent=parent)
+    box.setIcon(QMessageBox.Warning)
+    box.setText(message)
+    box.setWindowTitle(title)
+    box.setStandardButtons(QMessageBox.Ok)
+    box.exec_()

--- a/cubeviz/tools/moment_maps.py
+++ b/cubeviz/tools/moment_maps.py
@@ -5,7 +5,7 @@ from qtpy import QtGui
 from qtpy.QtWidgets import (QDialog, QComboBox, QPushButton,
                             QLabel, QWidget, QHBoxLayout, QVBoxLayout)
 
-from .common import add_to_2d_container
+from .common import add_to_2d_container, show_error_message
 
 
 # TODO: In the future, it might be nice to be able to work across data_collection elements
@@ -92,19 +92,15 @@ class MomentMapsGUI(QDialog):
         import spectral_cube
         cube = spectral_cube.SpectralCube(self.data[data_name], wcs=self.data.coords.wcs)
 
-        try:
-            cube_moment = cube.moment(order=order, axis=0)
+        cube_moment = cube.moment(order=order, axis=0)
 
-            self.label = '{}-moment-{}'.format(data_name, order)
+        self.label = '{}-moment-{}'.format(data_name, order)
 
-            # Add new overlay/component to cubeviz. We add this both to the 2D
-            # container Data object and also as an overlay. In future we might be
-            # able to use the 2D container Data object for the overlays directly.
-            add_to_2d_container(self.parent, self.data, cube_moment.value, self.label)
-            self.parent.add_overlay(cube_moment.value, self.label, display_now=False)
-
-        except Exception as e:
-            print('Error {}'.format(e))
+        # Add new overlay/component to cubeviz. We add this both to the 2D
+        # container Data object and also as an overlay. In future we might be
+        # able to use the 2D container Data object for the overlays directly.
+        add_to_2d_container(self.parent, self.data, cube_moment.value, self.label)
+        self.parent.add_overlay(cube_moment.value, self.label, display_now=False)
 
     def calculate_callback(self):
         """
@@ -116,7 +112,11 @@ class MomentMapsGUI(QDialog):
         order = int(self.order_combobox.currentText())
         data_name = self.data_combobox.currentText()
 
-        self.do_calculation(order, data_name)
+        try:
+            self.do_calculation(order, data_name)
+        except Exception as e:
+            print('Error: {}'.format(e))
+            show_error_message(str(e), 'Moment Map Error', parent=self)
 
         self.close()
 


### PR DESCRIPTION
This fixes #319. It should maybe eventually be generalized to all tools (including smoothing) to prevent creation of duplicate data components.