### PR TITLE
Move viewer controls to individual viewer toolbars

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -633,6 +633,8 @@ class CubevizImageViewer(ImageViewer, HubListener):
             else:
                 self.update_slice_index(index)
 
+        self.parent().slice_text.setText('slice: {:5}'.format(self._slice_index))
+
     def update_slice_index(self, index):
         """
         Function to update image and slice index.

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -246,24 +246,23 @@ class CubevizImageViewer(ImageViewer, HubListener):
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
     def _create_stats_axes(self, subset, median, mu, sigma):
-        rect = 0.01, 0.87, 0.20, 0.12
+        rect = 0.01, 0.87, 0.15, 0.12
         axes = self.figure.add_axes(rect, xticks=[], yticks=[])
         circle = Circle((0.15,0.85), 0.05, color=subset.style.color)
         axes.add_artist(circle)
 
         text_opts = dict(x=0.05, size='smaller')
-        axes.text(size='smaller', x=0.35, y=0.75, s='slice: {}'.format(self._slice_index))
         axes.text(**text_opts, y=0.52, s=r'$\widetilde{{x}} = {:.3}$'.format(median))
         axes.text(**text_opts, y=0.28, s=r'$\mu = {:.3}$'.format(mu))
         axes.text(**text_opts, y=0.02, s=r'$\sigma = {:.3}$'.format(sigma))
         return axes
 
     def _update_stats_text(self, median, mu, sigma):
-        median_text = self._stats_axes.texts[1]
+        median_text = self._stats_axes.texts[0]
         median_text.set_text(r'$\widetilde{{x}} = {:.3}$'.format(median))
-        mu_text = self._stats_axes.texts[2]
+        mu_text = self._stats_axes.texts[1]
         mu_text.set_text(r'$\mu = {:.3}$'.format(mu))
-        sigma_text = self._stats_axes.texts[3]
+        sigma_text = self._stats_axes.texts[2]
         sigma_text.set_text(r'$\sigma = {:.3}$'.format(sigma))
 
     def _calculate_stats(self, component, subset):
@@ -306,9 +305,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
         if self._stats_axes is None or self._has_2d_data or self._subset.ndim != 3:
             return
 
-        slice_text = self._stats_axes.texts[0]
-        slice_text.set_text('slice: {}'.format(self._slice_index))
-        median, mu, sigma = self._calculate_stats(self._component, self._subset)
+        median, mu, sigma = self._calculate_stats(self.current_component_id, self._subset)
         self._update_stats_text(median, mu, sigma)
         self.redraw()
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -64,6 +64,14 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.checkbox = QtWidgets.QCheckBox('Synced', enabled=False, checked=True)
         self.tb.addWidget(self.checkbox)
 
+        # Add a spacer so that the slice text is right-aligned
+        self.spacer = QtWidgets.QWidget()
+        self.spacer.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.tb.addWidget(self.spacer)
+
+        self.slice_text = QtWidgets.QLabel('')
+        self.tb.addWidget(self.slice_text)
+
         self.layout.addWidget(self.tb)
 
     def widget(self):
@@ -619,11 +627,12 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._slice_controller.enable()
         self._wavelength_controller.enable(str(wcs.wcs.cunit[2]), wavelengths)
 
-
         self._enable_option_buttons()
         self._setup_syncing()
 
         self._enable_all_viewer_combos(data)
+        for viewer in self.cube_views:
+            viewer.slice_text.setText('slice: {:5}'.format(self.synced_index))
 
         self.subWindowActivated.emit(self._active_view)
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -176,7 +176,6 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Set the default to parallel image viewer
         self._single_viewer_mode = False
         self.ui.button_toggle_image_mode.setText('Single Image Viewer')
-        self.ui.viewer_control_frame.setCurrentIndex(0)
 
         # Add this class to the specviz dispatcher watcher
         dispatch.setup(self)
@@ -663,7 +662,6 @@ class CubeVizLayout(QtWidgets.QWidget):
             self._activate_split_image_mode(event)
             self._single_viewer_mode = False
             self.ui.button_toggle_image_mode.setText('Single Image Viewer')
-            self.ui.viewer_control_frame.setCurrentIndex(0)
 
             for view in self.split_views:
                 if self.single_view._widget.synced:
@@ -678,7 +676,6 @@ class CubeVizLayout(QtWidgets.QWidget):
             self._activate_single_image_mode(event)
             self._single_viewer_mode = True
             self.ui.button_toggle_image_mode.setText('Split Image Viewer')
-            self.ui.viewer_control_frame.setCurrentIndex(1)
             self._active_view._widget.update()
 
         self.subWindowActivated.emit(new_active_view)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -56,6 +56,10 @@ class WidgetWrapper(QtWidgets.QWidget):
 
     def create_toolbar(self):
         self.tb = QtWidgets.QToolBar()
+
+        self.checkbox = QtWidgets.QCheckBox('Synced', enabled=False, checked=True)
+        self.tb.addWidget(self.checkbox)
+
         self.layout.addWidget(self.tb)
 
     def widget(self):
@@ -113,12 +117,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         self.single_view = self.cube_views[0]
         self.split_views = self.cube_views[1:]
 
-        self._synced_checkboxes = [
-            self.ui.singleviewer_synced_checkbox,
-            self.ui.viewer1_synced_checkbox,
-            self.ui.viewer2_synced_checkbox,
-            self.ui.viewer3_synced_checkbox
-        ]
+        self._synced_checkboxes = [view.checkbox for view in self.cube_views]
 
         for view, checkbox in zip(self.cube_views, self._synced_checkboxes):
             view._widget.assign_synced_checkbox(checkbox)
@@ -604,7 +603,8 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         # Store pointer to wcs and wavelength information
         wcs = self.session.data_collection.data[0].coords.wcs
-        wavelengths = self.single_view._widget._data[0].coords.world_axis(self.single_view._widget._data[0], axis=0)
+        wavelengths = self.single_view._widget._data[0].coords.world_axis(
+            self.single_view._widget._data[0], axis=0)
 
         # TODO: currently this way of accessing units is not flexible
         self._slice_controller.enable()

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -35,6 +35,7 @@ from .tools.spectral_operations import SpectralOperationHandler
 
 
 DEFAULT_NUM_SPLIT_VIEWERS = 3
+DEFAULT_TOOLBAR_ICON_SIZE = 18
 
 
 class WidgetWrapper(QtWidgets.QWidget):
@@ -111,6 +112,8 @@ class CubeVizLayout(QtWidgets.QWidget):
                     toolbar=True)
             self.cube_views.append(ww)
             ww._widget.register_to_hub(self.session.hub)
+
+        self.set_toolbar_icon_size(DEFAULT_TOOLBAR_ICON_SIZE)
 
         # Create specviz viewer and register to the hub.
         self.specviz = WidgetWrapper(
@@ -248,6 +251,10 @@ class CubeVizLayout(QtWidgets.QWidget):
                 act.triggered.connect(v)
                 menu_widget.addAction(act)
         return menu_widget
+
+    def set_toolbar_icon_size(self, size):
+        for view in self.cube_views:
+            view._widget.toolbar.setIconSize(QtCore.QSize(size, size))
 
     def handle_settings_change(self, message):
         if isinstance(message, SettingsChangeMessage):

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -553,11 +553,7 @@ class CubeVizLayout(QtWidgets.QWidget):
         """
         Get viewer combo for a given viewer index
         """
-        if view_index == 0:
-            combo_label = 'single_viewer_combo'
-        else:
-            combo_label = 'viewer{0}_combo'.format(view_index)
-        return getattr(self.ui, combo_label)
+        return self.cube_views[view_index].combo
 
     def add_overlay(self, data, label, display_now=True):
         self._overlay_controller.add_overlay(data, label, display=display_now)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -57,6 +57,9 @@ class WidgetWrapper(QtWidgets.QWidget):
     def create_toolbar(self):
         self.tb = QtWidgets.QToolBar()
 
+        self.combo = QtWidgets.QComboBox(enabled=False)
+        self.tb.addWidget(self.combo)
+
         self.checkbox = QtWidgets.QCheckBox('Synced', enabled=False, checked=True)
         self.tb.addWidget(self.checkbox)
 
@@ -461,13 +464,13 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         return _on_viewer_combo_change
 
-    def _enable_viewer_combo(self, data, index, combo_label, selection_label):
-        combo = getattr(self.ui, combo_label)
-        connect_combo_selection(self, selection_label, combo)
+    def _enable_viewer_combo(self, viewer, data, index, selection_label):
+        connect_combo_selection(self, selection_label, viewer.combo)
         helper = ComponentIDComboHelper(self, selection_label)
         helper.set_multiple_data([data])
-        combo.setEnabled(True)
-        combo.currentIndexChanged.connect(self._get_change_viewer_combo_func(combo, index))
+        viewer.combo.setEnabled(True)
+        viewer.combo.currentIndexChanged.connect(
+            self._get_change_viewer_combo_func(viewer.combo, index))
         self._viewer_combo_helpers.append(helper)
 
     def _enable_all_viewer_combos(self, data):
@@ -479,10 +482,10 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         :return:
         """
-        self._enable_viewer_combo(
-            data, 0, 'single_viewer_combo', 'single_viewer_attribute')
         view = self.cube_views[0].widget()
-        component = getattr(self, 'single_viewer_attribute')
+        self._enable_viewer_combo(view.parent(), data, 0, 'single_viewer_attribute')
+
+        component = self.single_viewer_attribute
         view.current_component_id = component
         view.cubeviz_unit = self._flux_unit_controller.get_component_unit(component,
                                                                           cubeviz_unit=True)
@@ -490,10 +493,10 @@ class CubeVizLayout(QtWidgets.QWidget):
         view.update_axes_title(component.label)
 
         for i in range(1,4):
-            combo_label = 'viewer{0}_combo'.format(i)
-            selection_label = 'viewer{0}_attribute'.format(i)
-            self._enable_viewer_combo(data, i, combo_label, selection_label)
             view = self.cube_views[i].widget()
+            selection_label = 'viewer{0}_attribute'.format(i)
+            self._enable_viewer_combo(view.parent(), data, i, selection_label)
+
             component = getattr(self, selection_label)
             view.current_component_id = component
             view.cubeviz_unit = self._flux_unit_controller.get_component_unit(component,

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -39,14 +39,24 @@ DEFAULT_NUM_SPLIT_VIEWERS = 3
 
 class WidgetWrapper(QtWidgets.QWidget):
 
-    def __init__(self, widget=None, tab_widget=None, parent=None):
+    def __init__(self, widget=None, tab_widget=None, toolbar=False, parent=None):
         super(WidgetWrapper, self).__init__(parent=parent)
         self.tab_widget = tab_widget
         self._widget = widget
+
         self.layout = QtWidgets.QVBoxLayout()
+        self.layout.setSpacing(0)
         self.layout.setContentsMargins(0, 0, 0, 0)
+
+        if toolbar:
+            self.create_toolbar()
+
         self.layout.addWidget(widget)
         self.setLayout(self.layout)
+
+    def create_toolbar(self):
+        self.tb = QtWidgets.QToolBar()
+        self.layout.addWidget(self.tb)
 
     def widget(self):
         return self._widget
@@ -90,12 +100,14 @@ class CubeVizLayout(QtWidgets.QWidget):
         # Create the cube viewers and register to the hub.
         for _ in range(DEFAULT_NUM_SPLIT_VIEWERS + 1):
             ww = WidgetWrapper(CubevizImageViewer(
-                    self.session, cubeviz_layout=self), tab_widget=self)
+                    self.session, cubeviz_layout=self), tab_widget=self,
+                    toolbar=True)
             self.cube_views.append(ww)
             ww._widget.register_to_hub(self.session.hub)
 
         # Create specviz viewer and register to the hub.
-        self.specviz = WidgetWrapper(SpecVizViewer(self.session), tab_widget=self)
+        self.specviz = WidgetWrapper(
+            SpecVizViewer(self.session), tab_widget=self, toolbar=False)
         self.specviz._widget.register_to_hub(self.session.hub)
 
         self.single_view = self.cube_views[0]

--- a/cubeviz/layout.ui
+++ b/cubeviz/layout.ui
@@ -41,10 +41,13 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <property name="spacing">
+      <property name="horizontalSpacing">
        <number>10</number>
       </property>
-      <item row="2" column="9">
+      <property name="verticalSpacing">
+       <number>0</number>
+      </property>
+      <item row="2" column="8">
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -57,7 +60,7 @@
         </property>
        </spacer>
       </item>
-      <item row="2" column="10">
+      <item row="2" column="9">
        <widget class="QToolButton" name="sync_button">
         <property name="enabled">
          <bool>false</bool>
@@ -73,7 +76,60 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="6" alignment="Qt::AlignLeft">
+      <item row="2" column="6">
+       <widget class="QToolButton" name="view_option_button">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="text">
+         <string>View  </string>
+        </property>
+        <property name="popupMode">
+         <enum>QToolButton::InstantPopup</enum>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextOnly</enum>
+        </property>
+        <property name="arrowType">
+         <enum>Qt::NoArrow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="7">
+       <widget class="QToolButton" name="cube_option_button">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Data Processing</string>
+        </property>
+        <property name="popupMode">
+         <enum>QToolButton::InstantPopup</enum>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonTextOnly</enum>
+        </property>
+        <property name="arrowType">
+         <enum>Qt::NoArrow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="5" alignment="Qt::AlignLeft">
        <widget class="QGroupBox" name="groupBox">
         <property name="title">
          <string/>
@@ -85,7 +141,7 @@
          <property name="bottomMargin">
           <number>6</number>
          </property>
-         <item row="1" column="2">
+         <item row="1" column="3">
           <widget class="QColormapCombo" name="overlay_colormap_combo">
            <property name="enabled">
             <bool>false</bool>
@@ -110,35 +166,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="label_7">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="text">
-            <string>Color Map</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_8">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Overlay Display</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="1">
           <widget class="QComboBox" name="overlay_image_combo">
            <property name="enabled">
@@ -146,7 +173,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="3">
+         <item row="1" column="5">
           <widget class="QSlider" name="alpha_slider">
            <property name="enabled">
             <bool>false</bool>
@@ -174,7 +201,36 @@
            </property>
           </widget>
          </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_8">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Overlay Display</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="3">
+          <widget class="QLabel" name="label_7">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="text">
+            <string>Color Map</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="5">
           <widget class="QLabel" name="label">
            <property name="font">
             <font>
@@ -188,15 +244,9 @@
           </widget>
          </item>
         </layout>
-        <zorder>label_7</zorder>
-        <zorder>overlay_colormap_combo</zorder>
-        <zorder>label_8</zorder>
-        <zorder>overlay_image_combo</zorder>
-        <zorder>alpha_slider</zorder>
-        <zorder>label</zorder>
        </widget>
       </item>
-      <item row="2" column="2" alignment="Qt::AlignLeft">
+      <item row="2" column="1" alignment="Qt::AlignLeft">
        <widget class="QGroupBox" name="groupBox_2">
         <property name="font">
          <font>
@@ -214,7 +264,61 @@
          <property name="bottomMargin">
           <number>6</number>
          </property>
-         <item row="0" column="0" alignment="Qt::AlignHCenter">
+         <item row="2" column="1">
+          <widget class="QSlider" name="slice_slider">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>300</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Drag the slider to navigate through the slices of the cube</string>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QLineEdit" name="slice_textbox">
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Enter a slice index to go directly to that slice</string>
+           </property>
+           <property name="text">
+            <string>slice #</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="5">
+          <widget class="QLineEdit" name="wavelength_textbox">
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Enter a wavelength value to navigate to the slice corresponding to the nearest wavelength</string>
+           </property>
+           <property name="text">
+            <string>wavelength</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
           <widget class="QLabel" name="label_3">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -237,7 +341,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
+         <item row="0" column="3">
           <widget class="QLabel" name="label_2">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -260,7 +364,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
+         <item row="0" column="5">
           <widget class="QLabel" name="wavelength_textbox_label">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -278,60 +382,6 @@
            </property>
            <property name="text">
             <string>Wavelength</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QSlider" name="slice_slider">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>300</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Drag the slider to navigate through the slices of the cube</string>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="slice_textbox">
-           <property name="maximumSize">
-            <size>
-             <width>50</width>
-             <height>22</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Enter a slice index to go directly to that slice</string>
-           </property>
-           <property name="text">
-            <string>slice #</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QLineEdit" name="wavelength_textbox">
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>22</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Enter a wavelength value to navigate to the slice corresponding to the nearest wavelength</string>
-           </property>
-           <property name="text">
-            <string>wavelength</string>
            </property>
           </widget>
          </item>
@@ -361,292 +411,6 @@
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item row="2" column="7">
-       <widget class="QToolButton" name="view_option_button">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="text">
-         <string>View  </string>
-        </property>
-        <property name="popupMode">
-         <enum>QToolButton::InstantPopup</enum>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextOnly</enum>
-        </property>
-        <property name="arrowType">
-         <enum>Qt::NoArrow</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="8">
-       <widget class="QToolButton" name="cube_option_button">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Data Processing</string>
-        </property>
-        <property name="popupMode">
-         <enum>QToolButton::InstantPopup</enum>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextOnly</enum>
-        </property>
-        <property name="arrowType">
-         <enum>Qt::NoArrow</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QStackedWidget" name="viewer_control_frame">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <property name="currentIndex">
-         <number>1</number>
-        </property>
-        <widget class="QWidget" name="stackedWidget_3Page1">
-         <layout class="QGridLayout" name="gridLayout_3">
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QGroupBox" name="groupBox_3">
-            <property name="title">
-             <string/>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_5">
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QLabel" name="label_4">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                   <underline>false</underline>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Viewer 1</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="viewer1_synced_checkbox">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                 <property name="text">
-                  <string>Synced</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                 <property name="tristate">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="2" column="0">
-              <widget class="QComboBox" name="viewer1_combo">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="toolTip">
-                <string>Select data to display in left hand viewer</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QComboBox" name="viewer2_combo">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="toolTip">
-                <string>Select data to display in middle viewer</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QComboBox" name="viewer3_combo">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="toolTip">
-                <string>Select data to display in right hand viewer</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayout_3">
-               <item>
-                <widget class="QLabel" name="label_5">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Viewer 2</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="viewer2_synced_checkbox">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                 <property name="text">
-                  <string>Synced</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                 <property name="tristate">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="0" column="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
-               <item>
-                <widget class="QLabel" name="label_6">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Viewer 3</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="viewer3_synced_checkbox">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                 <property name="text">
-                  <string>Synced</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                 <property name="tristate">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="page">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item alignment="Qt::AlignLeft">
-           <widget class="QGroupBox" name="groupBox_4">
-            <property name="title">
-             <string/>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_6">
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="1" column="0">
-              <widget class="QComboBox" name="single_viewer_combo">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <item>
-                <widget class="QLabel" name="label_9">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Viewer Contents</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="singleviewer_synced_checkbox">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                 <property name="text">
-                  <string>Synced</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                 <property name="tristate">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
        </widget>
       </item>
      </layout>

--- a/cubeviz/tests/test_ui.py
+++ b/cubeviz/tests/test_ui.py
@@ -112,12 +112,11 @@ def check_data_component(layout, combo, index, widget):
         layout._data[current_label][layout.synced_index])
 
 def setup_combo_and_index(qtbot, layout, index):
+    combo = layout.get_viewer_combo(index)
     if index == 0:
         toggle_viewer(qtbot, layout)
-        combo = getattr(layout.ui, 'single_viewer_combo')
         synced_index = 0
     else:
-        combo = getattr(layout.ui, 'viewer{0}_combo'.format(index))
         synced_index = index - 1
 
     return combo, synced_index
@@ -126,12 +125,11 @@ def setup_combo_and_index(qtbot, layout, index):
 def test_viewer_dropdowns(qtbot, cubeviz_layout, viewer_index):
     combo, synced_index = setup_combo_and_index(
                                 qtbot, cubeviz_layout, viewer_index)
+    combo = cubeviz_layout.get_viewer_combo(viewer_index)
     if viewer_index == 0:
         toggle_viewer(qtbot, cubeviz_layout)
-        combo = getattr(cubeviz_layout.ui, 'single_viewer_combo')
         synced_index = 0
     else:
-        combo = getattr(cubeviz_layout.ui, 'viewer{0}_combo'.format(viewer_index))
         synced_index = min(viewer_index - 1, 1) # only two datasets
 
     widget = cubeviz_layout.cube_views[viewer_index]._widget


### PR DESCRIPTION
This is a step towards providing a more flexible layout (#304). The viewer combo boxes and sync buttons are now clearly associated with the individual viewers. This will make the controls easier to support and reason about when we eventually support a variable number of viewers and allow the viewers to be resized/repositioned.

![image](https://user-images.githubusercontent.com/2458487/38426532-ea31ce0e-3984-11e8-840e-8f7cf4771899.png)
