### PR TITLE
Pass cubeviz layout reference to specviz 

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -126,7 +126,7 @@ class CubeVizLayout(QtWidgets.QWidget):
 
         # Create specviz viewer and register to the hub.
         self.specviz = WidgetWrapper(
-            SpecVizViewer(self.session), tab_widget=self, toolbar=False)
+            SpecVizViewer(self.session, layout=self), tab_widget=self, toolbar=False)
         self.specviz._widget.register_to_hub(self.session.hub)
 
         self.single_view = self.cube_views[0]


### PR DESCRIPTION
Allows specviz to add new data cube components and overlays.