### PR TITLE
Improve display of slice and ROI statistics

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -258,6 +258,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
     def show_roi_stats(self, component, subset):
 
         if self._has_2d_data or subset.ndim != 3:
+            self.parent().set_stats_text('', '')
             return
 
         self._subset = subset
@@ -270,6 +271,10 @@ class CubevizImageViewer(ImageViewer, HubListener):
         self._update_stats_text(label, *results)
 
     def show_slice_stats(self):
+
+        if self._has_2d_data:
+            self.parent().set_stats_text('', '')
+            return
 
         self._subset = None
 

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -270,6 +270,19 @@ class CubevizImageViewer(ImageViewer, HubListener):
     def hide_roi_stats(self):
         self.parent().set_roi_text('')
 
+    def update_slice_stats(self):
+        data = self._data[0][self.current_component_id][self._slice_index]
+        if self.cubeviz_unit is not None:
+            wave = self.cubeviz_layout.get_wavelength(self.slice_index)
+            data = self.cubeviz_unit.convert_from_original_unit(data.copy(), wave=wave)
+
+        min_ = float(np.nanmin(data))
+        max_ = float(np.nanmax(data))
+
+        # TODO: have a dynamic way to determine sig figs
+        text = "min={:.4}, max={:.4}".format(min_, max_)
+        self.parent().set_slice_text(text)
+
     def update_roi_stats(self):
         if self._subset is None or self._has_2d_data or self._subset.ndim != 3:
             return
@@ -608,13 +621,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
         if self.is_contour_active:
             self.draw_contour()
 
-        data = self._data[0][self.current_component_id][self._slice_index]
-        min_ = float(np.nanmin(data))
-        max_ = float(np.nanmax(data))
-
-        # TODO: have a dynamic way to determine sig figs
-        text = "min={:.4}, max={:.4}".format(min_, max_)
-        self.parent().set_slice_text(text)
+        self.update_slice_stats()
         self.update_roi_stats()
 
     def fast_draw_slice_at_index(self, index):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -648,6 +648,13 @@ class CubevizImageViewer(ImageViewer, HubListener):
         if self.is_contour_active:
             self.draw_contour()
 
+        data = self._data[0][self.current_component_id][self._slice_index]
+        min_ = float(np.nanmin(data))
+        max_ = float(np.nanmax(data))
+
+        # TODO: have a dynamic way to determine sig figs
+        text = "slice min={:.4}, slice max={:.4}".format(min_, max_)
+        self.parent().set_stats_text(text)
         self.update_stats()
 
     def fast_draw_slice_at_index(self, index):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -246,7 +246,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
     def _update_stats_text(self, label, min_, max_, median, mu, sigma):
-        text = r"min={:.4}, max={:.4}, x̃={:.4}, μ={:.4}, σ={:.4}".format(min_, max_, median, mu, sigma)
+        text = r"min={:.4}, max={:.4}, median={:.4}, μ={:.4}, σ={:.4}".format(min_, max_, median, mu, sigma)
         self.parent().set_stats_text(label, text)
 
     def _calculate_stats(self, data):

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -247,7 +247,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
 
     def _update_stats_text(self, median, mu, sigma):
         text = r"x̃={:.4}, μ={:.4}, σ={:.4}".format(median, mu, sigma)
-        self.parent().set_roi_text(text)
+        self.parent().set_roi_text(self._subset.label, text)
 
     def _calculate_stats(self, component, subset):
         mask = subset.to_mask()[self._slice_index]
@@ -268,7 +268,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
         self._update_stats_text(median, mu, sigma)
 
     def hide_roi_stats(self):
-        self.parent().set_roi_text('')
+        self.parent().hide_roi_text()
 
     def update_slice_stats(self):
         data = self._data[0][self.current_component_id][self._slice_index]

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -320,12 +320,6 @@ class CubevizImageViewer(ImageViewer, HubListener):
 
         self.update_stats()
 
-    def set_stats_visible(self, visible):
-        self._stats_visible = visible
-        if self._stats_axes is not None:
-            self._stats_axes.set_visible(self._stats_visible and not self._stats_hidden)
-            self.redraw()
-
     @property
     def is_preview_active(self):
         return self.is_contour_preview_active or self.is_smoothing_preview_active

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -653,7 +653,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
         max_ = float(np.nanmax(data))
 
         # TODO: have a dynamic way to determine sig figs
-        text = "slice min={:.4}, slice max={:.4}".format(min_, max_)
+        text = "min={:.4}, max={:.4}".format(min_, max_)
         self.parent().set_stats_text(text)
         self.update_stats()
 

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # This file contains a sub-class of the glue image viewer with further
 # customizations.
 
@@ -202,9 +203,6 @@ class CubevizImageViewer(ImageViewer, HubListener):
         self._has_2d_data = False  # True if currently displayed data is 2D
         self._toggle_3d = False  # True if we just toggled from 2D to 3D
 
-        self._stats_axes = None
-        self._stats_visible = True  # Global configuration setting
-        self._stats_hidden = False  # Internal configuration: are stats hidden?
         self._subset = None # Keep track of currently active subset
 
         self.coord_label = QLabel("")  # Coord display
@@ -247,25 +245,9 @@ class CubevizImageViewer(ImageViewer, HubListener):
             cls = CubevizImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
-    def _create_stats_axes(self, subset, median, mu, sigma):
-        rect = 0.01, 0.87, 0.15, 0.12
-        axes = self.figure.add_axes(rect, xticks=[], yticks=[])
-        circle = Circle((0.15,0.85), 0.05, color=subset.style.color)
-        axes.add_artist(circle)
-
-        text_opts = dict(x=0.05, size='smaller')
-        axes.text(**text_opts, y=0.52, s=r'$\widetilde{{x}} = {:.3}$'.format(median))
-        axes.text(**text_opts, y=0.28, s=r'$\mu = {:.3}$'.format(mu))
-        axes.text(**text_opts, y=0.02, s=r'$\sigma = {:.3}$'.format(sigma))
-        return axes
-
     def _update_stats_text(self, median, mu, sigma):
-        median_text = self._stats_axes.texts[0]
-        median_text.set_text(r'$\widetilde{{x}} = {:.3}$'.format(median))
-        mu_text = self._stats_axes.texts[1]
-        mu_text.set_text(r'$\mu = {:.3}$'.format(mu))
-        sigma_text = self._stats_axes.texts[2]
-        sigma_text.set_text(r'$\sigma = {:.3}$'.format(sigma))
+        text = r"x̃={:.4}, μ={:.4}, σ={:.4}".format(median, mu, sigma)
+        self.parent().set_roi_text(text)
 
     def _calculate_stats(self, component, subset):
         mask = subset.to_mask()[self._slice_index]
@@ -275,7 +257,7 @@ class CubevizImageViewer(ImageViewer, HubListener):
             data = self.cubeviz_unit.convert_from_original_unit(data, wave=wave)
         return np.median(data), data.mean(), data.std()
 
-    def draw_stats_axes(self, component, subset):
+    def show_roi_stats(self, component, subset):
 
         if self._has_2d_data or subset.ndim != 3:
             return
@@ -283,42 +265,20 @@ class CubevizImageViewer(ImageViewer, HubListener):
         self._subset = subset
 
         median, mu, sigma = self._calculate_stats(component, subset)
+        self._update_stats_text(median, mu, sigma)
 
-        if self._stats_axes is None:
-            self._stats_axes = self._create_stats_axes(subset, median, mu, sigma)
-        else:
-            # TODO: we should probably stash a pointer to this in the long term
-            circle = self._stats_axes.artists[0]
-            circle.set_color(subset.style.color)
-            self._update_stats_text(median, mu, sigma)
-            self._stats_axes.set_visible(True and self._stats_visible)
+    def hide_roi_stats(self):
+        self.parent().set_roi_text('')
 
-        self._stats_hidden = False
-        self.redraw()
-
-    def hide_stats_axes(self):
-        if self._stats_axes is not None:
-            self._stats_axes.set_visible(False)
-            self._stats_hidden = True
-            self.redraw()
-
-    def update_stats(self):
-
-        if self._stats_axes is None or self._has_2d_data or self._subset.ndim != 3:
+    def update_roi_stats(self):
+        if self._subset is None or self._has_2d_data or self._subset.ndim != 3:
             return
 
         median, mu, sigma = self._calculate_stats(self.current_component_id, self._subset)
         self._update_stats_text(median, mu, sigma)
-        self.redraw()
 
     def update_component(self, component):
-        if self.has_2d_data and self._stats_axes is not None:
-            self._stats_axes.set_visible(False)
-            self.redraw()
-        elif self._stats_axes is not None:
-            self._stats_axes.set_visible(True and self._stats_visible)
-
-        self.update_stats()
+        self.update_roi_stats()
 
     @property
     def is_preview_active(self):
@@ -654,8 +614,8 @@ class CubevizImageViewer(ImageViewer, HubListener):
 
         # TODO: have a dynamic way to determine sig figs
         text = "min={:.4}, max={:.4}".format(min_, max_)
-        self.parent().set_stats_text(text)
-        self.update_stats()
+        self.parent().set_slice_text(text)
+        self.update_roi_stats()
 
     def fast_draw_slice_at_index(self, index):
         """

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -82,38 +82,27 @@ class WidgetWrapper(QtWidgets.QWidget):
     def create_stats(self):
 
         self.stats_widget = QtWidgets.QWidget()
-        self.stats_layout = QtWidgets.QHBoxLayout()
+        self.stats_layout = QtWidgets.QVBoxLayout()
+        self.stats_layout.setSpacing(0)
+        self.stats_layout.setContentsMargins(0, 0, 0, 0)
         self.stats_widget.setLayout(self.stats_layout)
         self.layout.addWidget(self.stats_widget)
 
         bold_font = QtGui.QFont()
         bold_font.setBold(True)
 
-        self.stats_layout.addWidget(
-            QtWidgets.QLabel('Slice Statistics:', font=bold_font))
+        self.stats_label = QtWidgets.QLabel('', font=bold_font)
+        self.stats_layout.addWidget(self.stats_label)
 
-        self.slice_stats_text = QtWidgets.QLabel()
-        self.stats_layout.addWidget(self.slice_stats_text)
-
-        self.roi_stats_label = QtWidgets.QLabel(font=bold_font)
-        self.stats_layout.addWidget(self.roi_stats_label)
-
-        self.roi_stats_text = QtWidgets.QLabel('')
-        self.stats_layout.addWidget(self.roi_stats_text)
+        self.stats_text = QtWidgets.QLabel()
+        self.stats_layout.addWidget(self.stats_text)
 
     def set_stats_visible(self, visible):
         self.stats_widget.setVisible(visible)
 
-    def set_slice_text(self, text):
-        self.slice_stats_text.setText(text)
-
-    def set_roi_text(self, subset_label, text):
-        self.roi_stats_label.setText('{} Statistics:'.format(subset_label))
-        self.roi_stats_text.setText(text)
-
-    def hide_roi_text(self):
-        self.roi_stats_label.setText('')
-        self.roi_stats_text.setText('')
+    def set_stats_text(self, label, text):
+        self.stats_label.setText(label)
+        self.stats_text.setText(text)
 
     def widget(self):
         return self._widget
@@ -321,10 +310,10 @@ class CubeVizLayout(QtWidgets.QWidget):
                 viewer._widget.show_roi_stats(combo.selection, message.subset)
         elif isinstance(message, SubsetDeleteMessage):
             for viewer in self.cube_views:
-                viewer._widget.hide_roi_stats()
+                viewer._widget.show_slice_stats()
         elif isinstance(message, EditSubsetMessage) and not message.subset:
             for viewer in self.cube_views:
-                viewer._widget.hide_roi_stats()
+                viewer._widget.show_slice_stats()
 
     def _set_pos_and_margin(self, axes, pos, marg):
         axes.set_position(pos)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -79,14 +79,22 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.layout.addWidget(self.tb)
 
     def create_stats(self):
+
         self.stats_widget = QtWidgets.QWidget()
-        self.stats_layout = QtWidgets.QVBoxLayout()
-        self.stats_layout.addWidget(QtWidgets.QLabel('Statistics'))
+        self.stats_layout = QtWidgets.QHBoxLayout()
         self.stats_widget.setLayout(self.stats_layout)
         self.layout.addWidget(self.stats_widget)
 
+        self.stats_layout.addWidget(QtWidgets.QLabel('Statistics:'))
+
+        self.stats_text = QtWidgets.QLabel()
+        self.stats_layout.addWidget(self.stats_text)
+
     def set_stats_visible(self, visible):
         self.stats_widget.setVisible(visible)
+
+    def set_stats_text(self, text):
+        self.stats_text.setText(text)
 
     def widget(self):
         return self._widget
@@ -630,6 +638,8 @@ class CubeVizLayout(QtWidgets.QWidget):
         wavelengths = self.single_view._widget._data[0].coords.world_axis(
             self.single_view._widget._data[0], axis=0)
 
+        self._enable_all_viewer_combos(data)
+
         # TODO: currently this way of accessing units is not flexible
         self._slice_controller.enable()
         self._wavelength_controller.enable(str(wcs.wcs.cunit[2]), wavelengths)
@@ -637,7 +647,6 @@ class CubeVizLayout(QtWidgets.QWidget):
         self._enable_option_buttons()
         self._setup_syncing()
 
-        self._enable_all_viewer_combos(data)
         for viewer in self.cube_views:
             viewer.slice_text.setText('slice: {:5}'.format(self.synced_index))
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from astropy.wcs.utils import wcs_to_celestial_frame
 from astropy.coordinates import BaseRADecFrame
 
-from qtpy import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore, QtGui
 from qtpy.QtWidgets import QMenu, QAction, QInputDialog, QActionGroup
 
 from glue.utils.qt import load_ui
@@ -85,12 +85,17 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.stats_widget.setLayout(self.stats_layout)
         self.layout.addWidget(self.stats_widget)
 
-        self.stats_layout.addWidget(QtWidgets.QLabel('Slice Statistics:'))
+        bold_font = QtGui.QFont()
+        bold_font.setBold(True)
+
+        self.stats_layout.addWidget(
+            QtWidgets.QLabel('Slice Statistics:', font=bold_font))
 
         self.slice_stats_text = QtWidgets.QLabel()
         self.stats_layout.addWidget(self.slice_stats_text)
 
-        self.stats_layout.addWidget(QtWidgets.QLabel('ROI Statistics:'))
+        self.stats_layout.addWidget(
+            QtWidgets.QLabel('ROI Statistics:', font=bold_font))
 
         self.roi_stats_text = QtWidgets.QLabel('hey there')
         self.stats_layout.addWidget(self.roi_stats_text)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -85,6 +85,9 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.stats_widget.setLayout(self.stats_layout)
         self.layout.addWidget(self.stats_widget)
 
+    def set_stats_visible(self, visible):
+        self.stats_widget.setVisible(visible)
+
     def widget(self):
         return self._widget
 
@@ -332,7 +335,7 @@ class CubeVizLayout(QtWidgets.QWidget):
     def _toggle_stats_display(self):
         self._stats_visible = not self._stats_visible
         for viewer in self.cube_views:
-            viewer._widget.set_stats_visible(self._stats_visible)
+            viewer.set_stats_visible(self._stats_visible)
 
     def _open_dialog(self, name, widget):
 

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -94,8 +94,8 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.slice_stats_text = QtWidgets.QLabel()
         self.stats_layout.addWidget(self.slice_stats_text)
 
-        self.stats_layout.addWidget(
-            QtWidgets.QLabel('ROI Statistics:', font=bold_font))
+        self.roi_stats_label = QtWidgets.QLabel(font=bold_font)
+        self.stats_layout.addWidget(self.roi_stats_label)
 
         self.roi_stats_text = QtWidgets.QLabel('')
         self.stats_layout.addWidget(self.roi_stats_text)
@@ -106,8 +106,13 @@ class WidgetWrapper(QtWidgets.QWidget):
     def set_slice_text(self, text):
         self.slice_stats_text.setText(text)
 
-    def set_roi_text(self, text):
+    def set_roi_text(self, subset_label, text):
+        self.roi_stats_label.setText('{} Statistics:'.format(subset_label))
         self.roi_stats_text.setText(text)
+
+    def hide_roi_text(self):
+        self.roi_stats_label.setText('')
+        self.roi_stats_text.setText('')
 
     def widget(self):
         return self._widget

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -39,7 +39,7 @@ DEFAULT_NUM_SPLIT_VIEWERS = 3
 DEFAULT_TOOLBAR_ICON_SIZE = 18
 
 
-class WidgetWrapper(QtWidgets.QWidget):
+class WidgetWrapper(QtWidgets.QFrame):
 
     def __init__(self, widget=None, tab_widget=None, toolbar=False, parent=None):
         super(WidgetWrapper, self).__init__(parent=parent)
@@ -51,6 +51,9 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.layout.setContentsMargins(0, 0, 0, 0)
 
         if toolbar:
+            self.setObjectName('widgetWrapper')
+            self.setStyleSheet(
+                '#widgetWrapper { border: 2px solid #aaa; border-radius: 2px }')
             self.create_toolbar()
 
         # Add the image viewer itself to the layout

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -52,8 +52,12 @@ class WidgetWrapper(QtWidgets.QWidget):
         if toolbar:
             self.create_toolbar()
 
+        # Add the image viewer itself to the layout
         self.layout.addWidget(widget)
         self.setLayout(self.layout)
+
+        if toolbar:
+            self.create_stats()
 
     def create_toolbar(self):
         self.tb = QtWidgets.QToolBar()
@@ -73,6 +77,13 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.tb.addWidget(self.slice_text)
 
         self.layout.addWidget(self.tb)
+
+    def create_stats(self):
+        self.stats_widget = QtWidgets.QWidget()
+        self.stats_layout = QtWidgets.QVBoxLayout()
+        self.stats_layout.addWidget(QtWidgets.QLabel('Statistics'))
+        self.stats_widget.setLayout(self.stats_layout)
+        self.layout.addWidget(self.stats_widget)
 
     def widget(self):
         return self._widget

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -85,16 +85,21 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.stats_widget.setLayout(self.stats_layout)
         self.layout.addWidget(self.stats_widget)
 
-        self.stats_layout.addWidget(QtWidgets.QLabel('Statistics:'))
+        self.stats_layout.addWidget(QtWidgets.QLabel('Slice Statistics:'))
 
-        self.stats_text = QtWidgets.QLabel()
-        self.stats_layout.addWidget(self.stats_text)
+        self.slice_stats_text = QtWidgets.QLabel()
+        self.stats_layout.addWidget(self.slice_stats_text)
+
+        self.stats_layout.addWidget(QtWidgets.QLabel('ROI Statistics:'))
+
+        self.roi_stats_text = QtWidgets.QLabel('hey there')
+        self.stats_layout.addWidget(self.roi_stats_text)
 
     def set_stats_visible(self, visible):
         self.stats_widget.setVisible(visible)
 
     def set_stats_text(self, text):
-        self.stats_text.setText(text)
+        self.slice_stats_text.setText(text)
 
     def widget(self):
         return self._widget

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -97,14 +97,17 @@ class WidgetWrapper(QtWidgets.QWidget):
         self.stats_layout.addWidget(
             QtWidgets.QLabel('ROI Statistics:', font=bold_font))
 
-        self.roi_stats_text = QtWidgets.QLabel('hey there')
+        self.roi_stats_text = QtWidgets.QLabel('')
         self.stats_layout.addWidget(self.roi_stats_text)
 
     def set_stats_visible(self, visible):
         self.stats_widget.setVisible(visible)
 
-    def set_stats_text(self, text):
+    def set_slice_text(self, text):
         self.slice_stats_text.setText(text)
+
+    def set_roi_text(self, text):
+        self.roi_stats_text.setText(text)
 
     def widget(self):
         return self._widget
@@ -309,10 +312,10 @@ class CubeVizLayout(QtWidgets.QWidget):
         self.refresh_viewer_combo_helpers()
         if isinstance(message, SubsetUpdateMessage):
             for combo, viewer in zip(self._viewer_combo_helpers, self.cube_views):
-                viewer._widget.draw_stats_axes(combo.selection, message.subset)
+                viewer._widget.show_roi_stats(combo.selection, message.subset)
         elif isinstance(message, SubsetDeleteMessage):
             for viewer in self.cube_views:
-                viewer._widget.hide_stats_axes()
+                viewer._widget.hide_roi_stats()
 
     def _set_pos_and_margin(self, axes, pos, marg):
         axes.set_position(pos)

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -13,7 +13,8 @@ from glue.config import qt_fixed_layout_tab
 from glue.external.echo import keep_in_sync, SelectionCallbackProperty
 from glue.external.echo.qt import connect_combo_selection
 from glue.core.data_combo_helper import ComponentIDComboHelper
-from glue.core.message import SettingsChangeMessage, SubsetUpdateMessage, SubsetDeleteMessage
+from glue.core.message import (SettingsChangeMessage, SubsetUpdateMessage,
+                               SubsetDeleteMessage, EditSubsetMessage)
 from glue.utils.matplotlib import freeze_margins
 from glue.dialogs.component_arithmetic.qt import ArithmeticEditorWidget
 
@@ -319,6 +320,9 @@ class CubeVizLayout(QtWidgets.QWidget):
             for combo, viewer in zip(self._viewer_combo_helpers, self.cube_views):
                 viewer._widget.show_roi_stats(combo.selection, message.subset)
         elif isinstance(message, SubsetDeleteMessage):
+            for viewer in self.cube_views:
+                viewer._widget.hide_roi_stats()
+        elif isinstance(message, EditSubsetMessage) and not message.subset:
             for viewer in self.cube_views:
                 viewer._widget.hide_roi_stats()
 

--- a/cubeviz/listener.py
+++ b/cubeviz/listener.py
@@ -3,7 +3,7 @@
 from glue.core import Hub, HubListener, Data, DataCollection
 from glue.core.message import (DataCollectionAddMessage, SettingsChangeMessage,
                                DataRemoveComponentMessage, SubsetMessage,
-                               DataAddComponentMessage)
+                               EditSubsetMessage, DataAddComponentMessage)
 from .layout import CubeVizLayout
 from .messages import FluxUnitsUpdateMessage
 
@@ -35,6 +35,8 @@ class CubevizManager(HubListener):
             self, DataRemoveComponentMessage, handler=self.handle_remove_component)
         self._hub.subscribe(
             self, SubsetMessage, handler=self.handle_subset_message)
+        self._hub.subscribe(
+            self, EditSubsetMessage, handler=self.handle_subset_message)
         self._hub.subscribe(
             self, FluxUnitsUpdateMessage, handler=self.handle_flux_units_update)
 


### PR DESCRIPTION
This PR provides a (hopefully) improved way of displaying slice and ROI statistics:

![image](https://user-images.githubusercontent.com/2458487/38461269-7e990cbe-3a99-11e8-9beb-f60c8ba36c37.png)

The statistics can be hidden using a view menu option:

![image](https://user-images.githubusercontent.com/2458487/38461271-99698aaa-3a99-11e8-90a4-9a5f249dadca.png)

The following should be improved/implemented before merging:
- [ ] Display the name of the active subset next to the ROI stats
- [ ] Emphasize the stats display somewhat so that it doesn't get lost in the UI