### PR TITLE
Fix for checking file existence if it is a comma separated list.

### DIFF
--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -86,9 +86,10 @@ def main(argv=sys.argv):
 
     # Check to make sure each file exists and raise an Exception
     # that will show in the popup if it does not exist.
-    for x in datafiles:
-        if not os.path.isfile(x):
-            raise IOError('The file {} does not exist'.format(x))
+    for fileparam in datafiles:
+        for filename in  fileparam.split(','):
+            if not os.path.isfile(filename.strip()):
+                raise IOError('The file {} does not exist'.format(filename))
 
     # Show the splash screen for 1 second
     timer = QTimer()


### PR DESCRIPTION
Swara noticed that if a comma separated list of files (e.g., `../data/kb170517_00151_mcubes.fits,../data/kb170517_00151_vcubes.fits`) is passed in then it fails out as it was checking to see if *that* was a file.  Now it does a split on `,` and checks each.