### PR TITLE
Fix undefined variable

### DIFF
--- a/cubeviz/controls/flux_units.py
+++ b/cubeviz/controls/flux_units.py
@@ -1066,7 +1066,7 @@ class FluxUnitController:
                     new_astropy_unit = u.def_unit(new_unit["name"], u.Unit(new_unit["base"]))
                 else:
                     new_astropy_unit = u.def_unit(new_unit["name"])
-            self.register_new_unit(new_astropy_unit)
+                self.register_new_unit(new_astropy_unit)
 
         self._define_new_physical_types()
 


### PR DESCRIPTION
I'm not 100% sure if this is the correct fix, but I was seeing errors such as:

```
Traceback (most recent call last):
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/utils/misc.py", line 58, in result
    return func(*args, **kwargs)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/app/qt/application.py", line 743, in _choose_load_data
    self.add_datasets(self.data_collection, data_wizard())
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/application_base.py", line 293, in add_datasets
    data_collection.extend(datasets)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/data_collection.py", line 93, in extend
    self.append(d)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/data_collection.py", line 79, in append
    self.hub.broadcast(msg)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/hub.py", line 217, in broadcast
    handler(message)
  File "/Users/tom/miniconda3/envs/dev/lib/python3.6/site-packages/cubeviz/listener.py", line 46, in handle_new_dataset
    self.configure_layout(data)
  File "/Users/tom/miniconda3/envs/dev/lib/python3.6/site-packages/cubeviz/listener.py", line 53, in configure_layout
    cubeviz_layout = self._app.add_fixed_layout_tab(CubeVizLayout)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/app/qt/application.py", line 903, in add_fixed_layout_tab
    tab = tab_cls(session=self.session)
  File "/Users/tom/miniconda3/envs/dev/lib/python3.6/site-packages/cubeviz/layout.py", line 172, in __init__
    self._flux_unit_controller = FluxUnitController(self)
  File "/Users/tom/miniconda3/envs/dev/lib/python3.6/site-packages/cubeviz/controls/flux_units.py", line 1069, in __init__
    self.register_new_unit(new_astropy_unit)
UnboundLocalError: local variable 'new_astropy_unit' referenced before assignment
```

We need tests! ✊😄 
