### PR TITLE
Add specviz tests

### DIFF
--- a/cubeviz/controls/flux_units.py
+++ b/cubeviz/controls/flux_units.py
@@ -913,7 +913,6 @@ class ConvertFluxUnitGUI(QDialog):
         self.setMinimumSize(400, 270)
 
         self.cubeviz_layout = controller.cubeviz_layout
-        self._hub = self.cubeviz_layout.session.hub
 
         self.controller = controller
         self.data = controller.data
@@ -1037,9 +1036,7 @@ class ConvertFluxUnitGUI(QDialog):
             return
 
         component_id = self.component_combo.currentData()
-        self.data.get_component(component_id).units = self.current_unit.unit_string
-        msg = FluxUnitsUpdateMessage(self, self.current_unit.unit, component_id)
-        self._hub.broadcast(msg)
+        self.controller.update_component_unit(component_id, self.current_unit)
         self.close()
 
     def cancel(self):
@@ -1053,7 +1050,9 @@ class FluxUnitController:
     handle one glue data.
     """
     def __init__(self, cubeviz_layout=None):
+
         self.cubeviz_layout = cubeviz_layout
+        self._hub = self.cubeviz_layout.session.hub
 
         # Load up configurations from yaml file
         with open(DEFAULT_FLUX_UNITS_CONFIGS, 'r') as yamlfile:
@@ -1314,6 +1313,12 @@ class FluxUnitController:
             else:
                 return self._components[component_id].unit
         return None
+
+    def update_component_unit(self, component_id, cubeviz_unit):
+
+        self.data.get_component(component_id).units = cubeviz_unit.unit_string
+        msg = FluxUnitsUpdateMessage(self, cubeviz_unit.unit, component_id)
+        self._hub.broadcast(msg)
 
     def set_data(self, data):
         """

--- a/cubeviz/tests/test_specviz_interaction.py
+++ b/cubeviz/tests/test_specviz_interaction.py
@@ -1,0 +1,20 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+
+import pytest
+
+from glue.core import roi
+
+
+def test_create_roi(cubeviz_layout):
+    viewer = cubeviz_layout.split_views[0]._widget
+    # Create a pretty arbitrary circular ROI
+    viewer.apply_roi(roi.CircularROI(xc=10, yc=10, radius=5))
+    assert len(cubeviz_layout._data.subsets) == 1
+
+    subset = cubeviz_layout._data.subsets[0]
+    specviz = cubeviz_layout.specviz._widget
+    assert subset in specviz._specviz_data_cache
+
+    layer = specviz._specviz_data_cache[subset]
+    assert layer in specviz._layer_list.all_layers

--- a/cubeviz/tests/test_specviz_interaction.py
+++ b/cubeviz/tests/test_specviz_interaction.py
@@ -15,6 +15,23 @@ def test_create_roi(cubeviz_layout):
     subset = cubeviz_layout._data.subsets[0]
     specviz = cubeviz_layout.specviz._widget
     assert subset in specviz._specviz_data_cache
+    assert len(specviz._specviz_data_cache) == 2
 
     layer = specviz._specviz_data_cache[subset]
     assert layer in specviz._layer_list.all_layers
+    # TODO: once this is fixed, there should be a test here to make sure the
+    # ROI is the only spectrum that is currently displayed
+
+def test_delete_roi(cubeviz_layout):
+    # This test assumes that an ROI was created by the previous test
+    dc = cubeviz_layout.session.application.data_collection
+    dc.remove_subset_group(dc.subset_groups[0])
+    assert len(cubeviz_layout._data.subsets) == 0
+
+    specviz = cubeviz_layout.specviz._widget
+    assert cubeviz_layout._data in specviz._specviz_data_cache
+    assert len(specviz._specviz_data_cache) == 1
+
+    layer = specviz._specviz_data_cache[cubeviz_layout._data]
+    assert layer in specviz._layer_list.all_layers
+    assert len(specviz._layer_list.all_layers) == 1

--- a/cubeviz/tests/test_specviz_interaction.py
+++ b/cubeviz/tests/test_specviz_interaction.py
@@ -27,8 +27,10 @@ def test_create_roi(cubeviz_layout):
 
     layer = specviz._specviz_data_cache[subset]
     assert layer in specviz._layer_list.all_layers
-    # TODO: once this is fixed, there should be a test here to make sure the
-    # ROI is the only spectrum that is currently displayed
+
+    # Make sure the ROI layer is the only visible spectrum
+    assert specviz_layer_visible(specviz, cubeviz_layout._data) == False
+    assert specviz_layer_visible(specviz, subset) == True
 
 def test_delete_roi(cubeviz_layout):
     # This test assumes that an ROI was created by the previous test

--- a/cubeviz/tests/test_specviz_interaction.py
+++ b/cubeviz/tests/test_specviz_interaction.py
@@ -3,8 +3,16 @@ import os
 
 import pytest
 
+from qtpy.QtCore import Qt
+
 from glue.core import roi
 
+
+def specviz_layer_visible(specviz_viewer, glue_layer):
+
+    specviz_layer = specviz_viewer._specviz_data_cache[glue_layer]
+    layer_item = specviz_viewer._layer_list.get_layer_item(specviz_layer)
+    return layer_item.checkState(0) == Qt.Checked
 
 def test_create_roi(cubeviz_layout):
     viewer = cubeviz_layout.split_views[0]._widget
@@ -35,3 +43,37 @@ def test_delete_roi(cubeviz_layout):
     layer = specviz._specviz_data_cache[cubeviz_layout._data]
     assert layer in specviz._layer_list.all_layers
     assert len(specviz._layer_list.all_layers) == 1
+
+def test_update_units(cubeviz_layout):
+    # This test checks for a bug that was previously in specviz that caused the
+    # main spectrum to reappear after an update in flux units
+    from astropy import units as u
+    spaxel = u.def_unit('spaxel', u.astrophys.pix)
+    u.add_enabled_units(spaxel)
+
+    new_unit = u.milliJansky / spaxel
+
+    class FakeCubevizUnit:
+        unit = new_unit
+        unit_string = new_unit.to_string()
+
+    viewer = cubeviz_layout.split_views[0]._widget
+    viewer.apply_roi(roi.CircularROI(xc=10, yc=10, radius=5))
+
+    controller = cubeviz_layout._flux_unit_controller
+    component_id = cubeviz_layout._data.find_component_id('018.DATA')
+    controller.update_component_unit(component_id, FakeCubevizUnit)
+
+    subset = cubeviz_layout._data.subsets[0]
+    specviz = cubeviz_layout.specviz._widget
+    assert subset in specviz._specviz_data_cache
+
+    layer = specviz._specviz_data_cache[cubeviz_layout._data]
+    assert layer in specviz._layer_list.all_layers
+
+    assert specviz_layer_visible(specviz, cubeviz_layout._data) == False
+    assert specviz_layer_visible(specviz, subset) == True
+
+    # Delete the subset when we're done
+    dc = cubeviz_layout.session.application.data_collection
+    dc.remove_subset_group(dc.subset_groups[0])


### PR DESCRIPTION
More testing of the interaction between specviz and cubeviz is desperately needed. Ideally specviz will provide some unit tests of its own, but in the meantime we will do our best to test interactions between specviz and cubeviz.