### PR TITLE
Units patch 

### DIFF
--- a/cubeviz/__init__.py
+++ b/cubeviz/__init__.py
@@ -4,6 +4,11 @@
 This is an Astropy affiliated package.
 """
 
+import astropy.units as units
+from .flux_equivalences import CustomFluxEquivalences
+units.equivalencies.spectral_density = CustomFluxEquivalences(units.equivalencies.spectral_density)
+units.spectral_density = units.equivalencies.spectral_density
+
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------

--- a/cubeviz/__init__.py
+++ b/cubeviz/__init__.py
@@ -6,6 +6,9 @@ This is an Astropy affiliated package.
 
 import astropy.units as units
 from .flux_equivalences import CustomFluxEquivalences
+# We override the units.equivalencies.spectral_density function with
+# CustomFluxEquivalences before the program starts. We expect all libraries
+# to access CustomFluxEquivalences when calling for units.equivalencies.spectral_density
 units.equivalencies.spectral_density = CustomFluxEquivalences(units.equivalencies.spectral_density)
 units.spectral_density = units.equivalencies.spectral_density
 

--- a/cubeviz/controls/flux_units.py
+++ b/cubeviz/controls/flux_units.py
@@ -488,11 +488,11 @@ class SpectralFluxDensity(CubeVizUnit):
 
             if self.area.decompose() == u.pix.decompose() \
                     and 'solid angle' in self._original_area.physical_type:
-                area = (self._original_area / pixel_area).decompose()
+                area = u.Unit((self._original_area / pixel_area).decompose())
                 new_value /= area.to(self.area)
             elif 'solid angle' in self.area.physical_type \
                     and self._original_area.decompose() == u.pix.decompose():
-                area = (self._original_area * pixel_area).decompose()
+                area = u.Unit((self._original_area * pixel_area).decompose())
                 new_value /= area.to(self.area)
             else:
                 new_value /= self._original_area.to(self.area)
@@ -1090,7 +1090,9 @@ class FluxUnitController:
             return None
         try:
             top_unit = u.Unit(self.wcs.wcs.cunit[0])
-            return proj_plane_pixel_area(self.wcs) * (top_unit ** 2) / u.pix
+            pixel_area = proj_plane_pixel_area(self.wcs) * (top_unit ** 2) / u.pix
+            u.spectral_density.pixel_scale = pixel_area
+            return pixel_area
         except (ValueError, AttributeError):
             return None
 

--- a/cubeviz/controls/flux_units.py
+++ b/cubeviz/controls/flux_units.py
@@ -1335,7 +1335,7 @@ class FluxUnitController:
         wcs = data.coords.wcs
         if wcs is not None:
             self.wcs = wcs
-        self.pixel_area()
+        self.pixel_area
 
     def converter(self, parent=None):
         """

--- a/cubeviz/controls/flux_units.py
+++ b/cubeviz/controls/flux_units.py
@@ -1091,7 +1091,7 @@ class FluxUnitController:
         try:
             top_unit = u.Unit(self.wcs.wcs.cunit[0])
             pixel_area = proj_plane_pixel_area(self.wcs) * (top_unit ** 2) / u.pix
-            u.spectral_density.pixel_scale = pixel_area
+            u.spectral_density.pixel_area = pixel_area
             return pixel_area
         except (ValueError, AttributeError):
             return None
@@ -1335,6 +1335,7 @@ class FluxUnitController:
         wcs = data.coords.wcs
         if wcs is not None:
             self.wcs = wcs
+        self.pixel_area()
 
     def converter(self, parent=None):
         """

--- a/cubeviz/flux_equivalences.py
+++ b/cubeviz/flux_equivalences.py
@@ -1,0 +1,51 @@
+from astropy import units as u
+from astropy.units.quantity import Quantity
+
+
+class CustomFluxEquivalences:
+    def __init__(self, spectral_density):
+        self.pixel_scale = None
+        self.default_spectral_density = spectral_density
+
+    def __call__(self, wave, factor=None):
+        pixel_area = self.pixel_scale
+        if pixel_area is not None:
+            if type(pixel_area) == Quantity:
+                pixel_area = pixel_area.to("arcsec2 / pix").value  # Convert to Quantity
+        default_spectral_density = self.default_spectral_density(wave, factor=None)
+        equivalencies = default_spectral_density[:]
+        added_area_units = []
+        for u1, u2, f1, f2 in default_spectral_density:
+            u1_pix = u1 / u.pix
+            u2_pix = u2 / u.pix
+
+            u1_area = u1 / (u.arcsec ** 2)
+            u2_area = u2 / (u.arcsec ** 2)
+
+            equivalencies.append((u1_pix, u2_pix, f1, f2))
+            equivalencies.append((u1_area, u2_area, f1, f2))
+
+            if pixel_area is not None:
+                equivalencies.append((u1_pix,
+                                      u2_area,
+                                      lambda x: f1(x) / pixel_area,
+                                      lambda x: f2(x) * pixel_area))
+                equivalencies.append((u1_area,
+                                      u2_pix,
+                                      lambda x: f1(x) * pixel_area,
+                                      lambda x: f2(x) / pixel_area))
+                if u1_area not in added_area_units:
+                    equivalencies.append((u1_area,
+                                          u1_pix,
+                                          lambda x: x * pixel_area,
+                                          lambda x: x / pixel_area))
+                    added_area_units.append(u1_area)
+
+                if u2_area not in added_area_units:
+                    equivalencies.append((u2_area,
+                                          u2_pix,
+                                          lambda x: x * pixel_area,
+                                          lambda x: x / pixel_area))
+                    added_area_units.append(u2_area)
+
+        return equivalencies

--- a/cubeviz/flux_equivalences.py
+++ b/cubeviz/flux_equivalences.py
@@ -3,12 +3,20 @@ from astropy.units.quantity import Quantity
 
 
 class CustomFluxEquivalences:
+    """
+    This class is intended to behave as a function.
+    It will replace astropy.units.equivalencies.spectral_density.
+    It saves the original spectral_destiny function and adds
+    flux units that are over pixels or arcsec**2. The class also
+    stores pixel_area information that is used to convert b/w the
+    pixels and arcsec**2.
+    """
     def __init__(self, spectral_density):
-        self.pixel_scale = None
+        self.pixel_area = None
         self.default_spectral_density = spectral_density
 
     def __call__(self, wave, factor=None):
-        pixel_area = self.pixel_scale
+        pixel_area = self.pixel_area
         if pixel_area is not None:
             if type(pixel_area) == Quantity:
                 pixel_area = pixel_area.to("arcsec2 / pix").value  # Convert to Quantity


### PR DESCRIPTION
This patch will allow SpecViz to use custom equivalencies via a modified function. This function is implemented as a callable class so that it contains some extra information. The replacement function overrides the defualt `astropy.units.equivalencies.spectral_density` during startup. From then on, all the modules that call `astropy.units.equivalencies.spectral_density` will actually be accessing the modified function (or class in this case). I will add more doc strings as I integrate this function into stage 3 units update.