### PR TITLE
2D image bug fix 

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -616,9 +616,11 @@ class CubevizImageViewer(ImageViewer):
 
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
-        if (active_widget.synced and self.synced and not \
-            self.cubeviz_layout._single_viewer_mode) or \
-                active_widget is self:
+        if (active_widget.synced and
+            self.synced and not
+            self.cubeviz_layout._single_viewer_mode and not
+            self._has_2d_data) or \
+            active_widget is self:
             if message.slider_down:
                 self.fast_draw_slice_at_index(index)
             else:

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -617,9 +617,9 @@ class CubevizImageViewer(ImageViewer):
         # If the active widget is synced then we need to update the image
         # in all the other synced views.
         if (active_widget.synced and
-            self.synced and not
-            self.cubeviz_layout._single_viewer_mode and not
-            self._has_2d_data) or \
+            self.synced and
+            not self.cubeviz_layout._single_viewer_mode and
+            not self._has_2d_data) or \
             active_widget is self:
             if message.slider_down:
                 self.fast_draw_slice_at_index(index)


### PR DESCRIPTION
When there is a 2d image being displayed on a synced viewer and the user tries to use the slider for the other viewers, the image viewer with the 2d image attempts to update its index resulting in an error. A nice way to test this bug is to collapse a  cube, make sure the viewer with the collapsed component is synced, turn on contour for that viewer and then try to use the slider of the other viewers. 