### PR TITLE
Version fixes for moving ahed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # conda packages here.
-        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core=0.13 asdf specviz=0.5 specutils=0.2.2'
+        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.13 asdf specviz=0.5 specutils=0.2.2'
         - CONDA_VERSION=4.3.31
 
         # List other runtime dependencies for the package that are available as

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # conda packages here.
-        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.14 asdf specviz=0.5 specutils=0.2.2'
+        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core=0.13 asdf specviz=0.5 specutils=0.2.2'
         - CONDA_VERSION=4.3.31
 
         # List other runtime dependencies for the package that are available as

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ env:
     matrix:
         # Make sure that egg_info works without dependencies
         - PYTHON_VERSION=3.6 MAIN_CMD='python setup.py' SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.7 MAIN_CMD='python setup.py' SETUP_CMD='egg_info'
 
 matrix:
 
@@ -74,8 +73,8 @@ matrix:
         #  env: SETUP_CMD='--coverage'
 
         # Test against Python 3.7
-        - os: linux
-          env: PYTHON_VERSION=3.7
+        #- os: linux
+        #  env: PYTHON_VERSION=3.7
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.5 MAIN_CMD='python setup.py' SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 MAIN_CMD='python setup.py' SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.7 MAIN_CMD='python setup.py' SETUP_CMD='egg_info'
 
 matrix:
 
@@ -73,9 +73,9 @@ matrix:
         # os: linux
         #  env: SETUP_CMD='--coverage'
 
-        # Test against Python 3.5
+        # Test against Python 3.7
         - os: linux
-          env: PYTHON_VERSION=3.5
+          env: PYTHON_VERSION=3.7
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # conda packages here.
-        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.13 asdf specviz=0.5 specutils=0.2.2'
+        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.14 asdf specviz=0.5 specutils=0.2.2'
         - CONDA_VERSION=4.3.31
 
         # List other runtime dependencies for the package that are available as

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # conda packages here.
-        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.12 asdf specviz=0.5'
+        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.12 asdf specviz=0.5 specutils=0.2.2'
         - CONDA_VERSION=4.3.31
 
         # List other runtime dependencies for the package that are available as

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # conda packages here.
-        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.12 asdf specviz=0.5 specutils=0.2.2'
+        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.13 asdf specviz=0.5 specutils=0.2.2'
         - CONDA_VERSION=4.3.31
 
         # List other runtime dependencies for the package that are available as

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
 
       NUMPY_VERSION: "stable"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core>=0.13 asdf specviz==0.5 specutils=0.2.2"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.14 asdf specviz==0.5 specutils=0.2.2"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   matrix:
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "3.0.4"
+        ASTROPY_VERSION: "3.0.1"
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ environment:
   matrix:
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "stable"
+        ASTROPY_VERSION: "3.0.4"
+        MATPLOTLIB_VERSION: "2.2"
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
 
       NUMPY_VERSION: "stable"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.14 asdf specviz==0.5 specutils=0.2.2"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 specutils=0.2.2"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,7 @@ environment:
                         # to the matrix section.
 
       NUMPY_VERSION: "stable"
-      SPECVIZ_GIT: "git+https://github.com/spacetelescope/specviz#egg=specviz"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 matplotlib"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 specutils=0.2.2"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   matrix:
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "3.0.4"
+        ASTROPY_VERSION: "stable"
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
 
       NUMPY_VERSION: "stable"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.14 asdf specviz==0.5 specutils=0.2.2"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core>=0.13 asdf specviz==0.5 specutils=0.2.2"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
       NUMPY_VERSION: "stable"
       SPECVIZ_GIT: "git+https://github.com/spacetelescope/specviz#egg=specviz"
-      CONDA_DEPENDENCIES: "pyqt matplotlib scipy glue-core==0.13 asdf specviz==0.5"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ environment:
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
       CONDA_CHANNELS: "glueviz/label/dev glueviz astropy-ci-extras astropy"
-      CONDA_VERSION: "4.3.31"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
   matrix:
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "stable"
+        ASTROPY_VERSION: "3.0.4"
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ environment:
                         # to the matrix section.
 
       NUMPY_VERSION: "stable"
-      CONDA_DEPENDENCIES: "pyqt matplotlib scipy glue-core>=0.12 asdf specviz=0.5"
+      SPECVIZ_GIT: "git+https://github.com/spacetelescope/specviz#egg=specviz"
+      CONDA_DEPENDENCIES: "pyqt matplotlib scipy glue-core==0.13 asdf specviz==0.5"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
 
       NUMPY_VERSION: "stable"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 specutils=0.2.2"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.14 asdf specviz==0.5 specutils=0.2.2"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel
@@ -25,9 +25,6 @@ environment:
   matrix:
 
       - PYTHON_VERSION: "3.6"
-        ASTROPY_VERSION: "stable"
-
-      - PYTHON_VERSION: "3.7"
         ASTROPY_VERSION: "stable"
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
       NUMPY_VERSION: "stable"
       SPECVIZ_GIT: "git+https://github.com/spacetelescope/specviz#egg=specviz"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 matplotlib==2.2"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel
@@ -27,7 +27,6 @@ environment:
 
       - PYTHON_VERSION: "3.5"
         ASTROPY_VERSION: "3.0.4"
-        MATPLOTLIB_VERSION: "2.2"
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
       NUMPY_VERSION: "stable"
       SPECVIZ_GIT: "git+https://github.com/spacetelescope/specviz#egg=specviz"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 matplotlib==2.2"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 matplotlib"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel
@@ -25,10 +25,10 @@ environment:
 
   matrix:
 
-      - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "3.0.1"
-
       - PYTHON_VERSION: "3.6"
+        ASTROPY_VERSION: "stable"
+
+      - PYTHON_VERSION: "3.7"
         ASTROPY_VERSION: "stable"
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
 
       NUMPY_VERSION: "stable"
-      CONDA_DEPENDENCIES: "pyqt scipy glue-core==0.13 asdf specviz==0.5 specutils=0.2.2"
+      CONDA_DEPENDENCIES: "pyqt scipy glue-core>=0.13 asdf specviz==0.5 specutils=0.2.2"
       PIP_DEPENDENCIES: "pytest-qt"
 
       # Conda packages for affiliated packages are hosted in channel

--- a/cubeviz/__init__.py
+++ b/cubeviz/__init__.py
@@ -4,14 +4,6 @@
 This is an Astropy affiliated package.
 """
 
-import astropy.units as units
-from .flux_equivalences import CustomFluxEquivalences
-# We override the units.equivalencies.spectral_density function with
-# CustomFluxEquivalences before the program starts. We expect all libraries
-# to access CustomFluxEquivalences when calling for units.equivalencies.spectral_density
-units.equivalencies.spectral_density = CustomFluxEquivalences(units.equivalencies.spectral_density)
-units.spectral_density = units.equivalencies.spectral_density
-
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
@@ -19,4 +11,12 @@ from ._internal_init import *
 # ----------------------------------------------------------------------------
 
 if _CUBEVIZ_SETUP_ is False:
+    import astropy.units as units
+    from .flux_equivalences import CustomFluxEquivalences
+    # We override the units.equivalencies.spectral_density function with
+    # CustomFluxEquivalences before the program starts. We expect all libraries
+    # to access CustomFluxEquivalences when calling for units.equivalencies.spectral_density
+    units.equivalencies.spectral_density = CustomFluxEquivalences(units.equivalencies.spectral_density)
+    units.spectral_density = units.equivalencies.spectral_density
+
     from . import keyboard_shortcuts

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -5,7 +5,7 @@ import argparse
 import os
 
 from glue.app.qt import GlueApplication
-from glue.main import restore_session, get_splash, load_data_files, load_plugins
+from glue.main import get_splash, load_data_files, load_plugins
 from qtpy.QtCore import QTimer
 from qtpy import QtGui, QtWidgets
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.3.dev
-install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core==0.13 specviz==0.5
+install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core==0.14 specviz==0.5
 
 [entry_points]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.3.dev
-install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core==0.13 specviz==0.5
+install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core>=0.13 specviz==0.5
 
 [entry_points]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,8 @@ url = https://github.com/spacetelescope/cubeviz
 edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 0.2.dev
-install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core>=0.12
+version = 0.3.dev
+install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core==0.13 specviz==0.5
 
 [entry_points]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.3.dev
-install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core==0.14 specviz==0.5
+install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core==0.13 specviz==0.5
 
 [entry_points]
 

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ import ah_bootstrap
 from setuptools import setup
 
 # A dirty hack to get around some early import/configurations ambiguities
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
+import builtins
 builtins._CUBEVIZ_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (register_commands, get_debug_option,


### PR DESCRIPTION
This sets the current version to 0.3.dev, fixes an import issue in cubeviz/__init__.py and version dependencies for glue core and specviz