### PR TITLE
Fix use of pytest fixtures to avoid errors with pytest>=4.1

### DIFF
--- a/cubeviz/tools/tests/test_collapse_cube.py
+++ b/cubeviz/tools/tests/test_collapse_cube.py
@@ -16,8 +16,7 @@ from ...tests.helpers import (toggle_viewer, select_viewer, left_click,
 DATA_LABELS = ['018.DATA', '018.NOISE']
 
 
-@pytest.fixture(scope='module')
-def collapse_cube(cubeviz_layout):
+def create_collapsed_cube(cubeviz_layout):
     cl = cubeviz_layout
 
     wavelengths = cubeviz_layout._wavelength_controller.wavelengths
@@ -28,13 +27,18 @@ def collapse_cube(cubeviz_layout):
     return cc
 
 
+@pytest.fixture(scope='module')
+def collapse_cube_gui(cubeviz_layout):
+    return create_collapsed_cube(cubeviz_layout)
+
+
 def assert_red_stylesheet(widget):
     assert widget.styleSheet() == "color: rgba(255, 0, 0, 128)"
 
 
-def test_collapse_ui(qtbot, collapse_cube):
+def test_collapse_ui(qtbot, collapse_cube_gui):
 
-    cc = collapse_cube
+    cc = collapse_cube_gui
     cc.ui.start_input.setText('a')
     qtbot.mouseClick(cc.ui.calculate_button, QtCore.Qt.LeftButton)
     assert_red_stylesheet(cc.ui.start_label)
@@ -69,9 +73,9 @@ def test_collapse_ui(qtbot, collapse_cube):
     assert_red_stylesheet(cc.ui.advanced_sigma_lower_label)
     assert_red_stylesheet(cc.ui.advanced_sigma_upper_label)
 
-def test_starting_state(cubeviz_layout):
+def test_starting_state(collapse_cube_gui, cubeviz_layout):
 
-    cc = collapse_cube(cubeviz_layout)
+    cc = collapse_cube_gui
 
     # No clipping
     data_name = DATA_LABELS[0]
@@ -131,7 +135,9 @@ def test_regions(qtbot, cubeviz_layout):
     # Create a pretty arbitrary circular ROI
     viewer.apply_roi(roi.CircularROI(xc=6, yc=10, radius=3))
 
-    cc = collapse_cube(cubeviz_layout)
+    # Don't use the fixture here since we modified the underlying viewer state
+    # above first.
+    cc = create_collapsed_cube(cubeviz_layout)
 
     start_index = 682
     end_index = 1364

--- a/cubeviz/tools/tests/test_moment_map.py
+++ b/cubeviz/tools/tests/test_moment_map.py
@@ -17,7 +17,7 @@ DATA_LABELS = ['018.DATA', '018.NOISE']
 
 
 @pytest.fixture(scope='module')
-def moment_maps(cubeviz_layout):
+def moment_maps_gui(cubeviz_layout):
     cl = cubeviz_layout
 
     mm = MomentMapsGUI(cl._data, cl.session.data_collection, parent=cl)
@@ -29,9 +29,9 @@ def assert_red_stylesheet(widget):
     assert widget.styleSheet() == "color: rgba(255, 0, 0, 128)"
 
 
-def test_moment_maps_1(cubeviz_layout):
+def test_moment_maps_1(moment_maps_gui, cubeviz_layout):
     # Create GUI
-    mm = moment_maps(cubeviz_layout)
+    mm = moment_maps_gui
     mm.display()
     mm.order_combobox.setCurrentIndex(0)
     mm.data_combobox.setCurrentIndex(0)
@@ -50,9 +50,9 @@ def test_moment_maps_1(cubeviz_layout):
 
     assert np.allclose(cube_moment, np_result, rtol=0.01, equal_nan=True)
 
-def test_moment_maps_2(cubeviz_layout):
+def test_moment_maps_2(moment_maps_gui, cubeviz_layout):
     # Create GUI
-    mm = moment_maps(cubeviz_layout)
+    mm = moment_maps_gui
     mm.display()
     mm.order_combobox.setCurrentIndex(1)
     mm.data_combobox.setCurrentIndex(0)

--- a/cubeviz/tools/tests/test_smoothing_gui.py
+++ b/cubeviz/tools/tests/test_smoothing_gui.py
@@ -18,7 +18,7 @@ DATA_LABELS = ['018.DATA', '018.NOISE']
 
 
 @pytest.fixture(scope='module')
-def smoothing(cubeviz_layout):
+def smoothing_gui(cubeviz_layout):
     cl = cubeviz_layout
 
     sm = SelectSmoothing(cl._data, parent=cl)
@@ -30,11 +30,11 @@ def assert_red_stylesheet(widget):
     assert widget.styleSheet() == "color: rgba(255, 0, 0, 128)"
 
 @pytest.mark.parametrize("x", [0,1,2,3,4,5])
-def test_smoothing_spatial(qtbot, cubeviz_layout, x):
+def test_smoothing_spatial(qtbot, smoothing_gui, cubeviz_layout, x):
     # TODO: test spectral as well
 
     # Create GUI
-    sm = smoothing(cubeviz_layout)
+    sm = smoothing_gui
     sm.k_size.setText("1")          # Kernel size
     sm.combo.setCurrentIndex(x)         # Kernel type
     sm.component_combo.setCurrentIndex(0)       # Data componenet


### PR DESCRIPTION
Calling fixtures directly had been deprecated in `pytest` for a while, but it's no longer supported at all in 4.1. The easiest fix is simply to factor out the logic of the fixture into a standalone function that can be called both by the existing fixture and also separately when needed.