### PR TITLE
Fix for specviz version requirement

### DIFF
--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -18,7 +18,7 @@ from glue.core.message import (SettingsChangeMessage, SubsetUpdateMessage,
 from glue.utils.matplotlib import freeze_margins
 from glue.dialogs.component_arithmetic.qt import ArithmeticEditorWidget
 
-from specviz.third_party.glue.data_viewer import SpecVizViewer
+from specviz.third_party.glue.viewer import SpecVizViewer
 from specviz.core.events import dispatch
 
 from .toolbar import CubevizToolbar

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.3.dev
-install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core>=0.13 specviz==0.5
+install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core>=0.13 specviz>=0.5
 
 [entry_points]
 


### PR DESCRIPTION
Updated specviz version requirement to include versions greater than 0.5 to fix issues with conda builds.