### PR TITLE
Main test should be against released glue-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # are in astropy-ci-extras. If your package uses either of these,
         # add the channels to CONDA_CHANNELS along with any other channels
         # you want to use.
-        - CONDA_CHANNELS='glueviz/label/dev glueviz astropy-ci-extras astropy'
+        - CONDA_CHANNELS='glueviz astropy-ci-extras astropy'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.


### PR DESCRIPTION
Removed glueviz-dev conda channel for main testing as it should be against the released glue-core version.