### PR TITLE
Use tox for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ matrix:
         - os: windows
           env: TOXENV='py36'
 
+        # Test against Py37 (expected to fail for now)
+        - env: TOXENV='py37'
+
         # Try building against Astropy dev
         - env: TOXENV='py36-astrodev'
 
@@ -69,6 +72,7 @@ matrix:
 
     allow_failures:
         - env: TOXENV='style' TOX_ARGS=''
+        - env: TOXENV='py37'
         - env: TOXENV='py36-astrodev'
         - env: TOXENV='py36-numpydev'
         - env: TOXENV='py36-gluedev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ matrix:
         - env: TOXENV='py36-gluedev'
 
     allow_failures:
+        - env: TOXENV='style' TOX_ARGS=''
         - env: TOXENV='py36-astrodev'
         - env: TOXENV='py36-numpydev'
         - env: TOXENV='py36-gluedev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,49 +14,23 @@ sudo: false
 #
 # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
 
-#addons:
-#    apt:
-#        packages:
-#            - graphviz
-#            - texlive-latex-extra
-#            - dvipng
-
 env:
     global:
 
         # The following versions are the 'default' for tests, unless
-        # overridden underneath. They are defined here in order to save having
+        # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.6
-        - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=stable
-        # Pull specviz from github until it is released on PyPi and/or conda
-        - MAIN_CMD='pytest'
-        - SETUP_CMD=''
-        - EVENT_TYPE='pull_request push'
-
-        # List other runtime dependencies for the package that are available as
-        # conda packages here.
-        - CONDA_DEPENDENCIES='pyqt matplotlib scipy glue-core>=0.13 asdf specviz=0.5 specutils=0.2.2'
-
-        # List other runtime dependencies for the package that are available as
-        # pip packages here.
-        - PIP_DEPENDENCIES="pytest-qt"
-
-        # Conda packages for affiliated packages are hosted in channel
-        # "astropy" while builds for astropy LTS with recent numpy versions
-        # are in astropy-ci-extras. If your package uses either of these,
-        # add the channels to CONDA_CHANNELS along with any other channels
-        # you want to use.
-        - CONDA_CHANNELS='glueviz astropy-ci-extras astropy'
-
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
+        - TOX_CMD='tox --'
+        - TOX_ARGS='--remote-data'
         - SETUP_XVFB=True
 
     matrix:
-        # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.6 MAIN_CMD='python setup.py' SETUP_CMD='egg_info'
+        # Make sure that installation does not fail
+        - TOXENV='py36' TOX_CMD='tox --notest' TOX_ARGS=''
+        # Make sure README will display properly on pypi
+        - TOXENV='checkdocs'
+        # Run a test with stable dependencies
+        - TOXENV='py36'
 
 matrix:
 
@@ -64,86 +38,47 @@ matrix:
     fast_finish: true
 
     include:
-        # Try MacOS X and Windows
-        - os: osx
+        # Do a coverage test
+        - env: TOXENV='coverage' TOX_ARGS=''
 
-        - os: windows
-
-        # Do a coverage test.
-        # os: linux
-        #  env: SETUP_CMD='--coverage'
-
-        # Test against Python 3.7
-        #- os: linux
-        #  env: PYTHON_VERSION=3.7
+        # Perform a sanity check of packaging using twine
+        - env: TOXENV='twine' TOX_ARGS=''
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        #- os: linux
-        #  env: SETUP_CMD='build_docs -w'
+        - env: TOXENV='docbuild' TOX_ARGS=''
+
+        # Do a code style check
+        - env: TOXENV='style' TOX_ARGS=''
+
+        # Try MacOS X and Windows
+        - os: osx
+          env: TOXENV='py36'
+
+        - os: windows
+          env: TOXENV='py36'
 
         # Try building against Astropy dev
-        - os: linux
-          env: ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
-
-        # Test against older version of numpy
-        - os: linux
-          env: NUMPY_VERSION=1.13
+        - env: TOXENV='py36-astrodev'
 
         # Test against numpy dev
-        - os: linux
-          env: NUMPY_VERSION=dev
+        - env: TOXENV='py36-numpydev'
 
         # Test against latest development version of Glue
-        - os: linux
-          env: CONDA_CHANNELS='glueviz/label/dev glueviz'
-
-        # Do a PEP8 test with pycodestyle
-        - os: linux
-          env: MAIN_CMD='pycodestyle cubeviz --count' SETUP_CMD=''
+        - env: TOXENV='py36-gluedev'
 
     allow_failures:
-        # Allow failures against numpy dev
-        - os: linux
-          env: NUMPY_VERSION=dev
-        # Allow failures against development version of Glue
-        - os: linux
-          env: CONDA_CHANNELS='glueviz/label/dev glueviz'
+        - env: TOXENV='py36-astrodev'
+        - env: TOXENV='py36-numpydev'
+        - env: TOXENV='py36-gluedev'
 
 install:
-
-    # We now use the ci-helpers package to set up our testing environment.
-    # This is done by using Miniconda and then using conda and pip to install
-    # dependencies. Which dependencies are installed using conda and pip is
-    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
-    # which should be space-delimited lists of package names. See the README
-    # in https://github.com/astropy/ci-helpers for information about the full
-    # list of environment variables that can be used to customize your
-    # environment. In some cases, ci-helpers may not offer enough flexibility
-    # in how to install a package, in which case you can have additional
-    # commands in the install: section below.
-
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-
-    # As described above, using ci-helpers, you should be able to set up an
-    # environment with dependencies installed using conda and pip, but in some
-    # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python
-    # dependencies). Therefore, you can also include commands below (as
-    # well as at the start of the install section or in the before_install
-    # section if they are needed before setting up conda) to install any
-    # other dependencies.
+    - pip install tox tox-conda
 
 script:
    - conda info
-   - conda list
-   - $MAIN_CMD $SETUP_CMD
+   - $TOX_CMD $TOX_ARGS
    - find cubeviz -name "*.ui" -exec grep "pointsize" {} \; >& font.log
    - test ! -s font.log
-
-after_success:
-    # If coveralls.io is set up for this package, uncomment the line below.
-    # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='cubeviz/tests/coveragerc'; fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,18 @@
 CubeViz: Visualization & Analysis Tool for Data Cubes from Integral Field Units (IFUs)
 ======================================================================================
 
-CubeViz is an visualization and analysis toolbox for data cubes from `integral field units (IFUs) <https://jwst-docs.stsci.edu/display/JPP/Introduction+to+IFU+Spectroscopy>`_.  It is built as part of the `glue visualiztion tool <http://glueviz.org>`_.  CubeViz is designed to work with data cubes from the `NIRSpec <https://jwst-docs.stsci.edu/display/JTI/NIRSpec+IFU+Spectroscopy>`_ and `MIRI <https://jwst-docs.stsci.edu/display/JTI/MIRI+Medium-Resolution+Spectroscopy>`_ instruments on `JWST <https://jwst-docs.stsci.edu/display/HOM/JWST+User+Documentation+Home>`_, and will work with data cubes from any IFU.  It uses the `specutils <https://specutils.readthedocs.io/en/latest/>`_ package from `Astropy <http://www.astropy.org>`_.
+CubeViz is an visualization and analysis toolbox for data cubes from `integral
+field units (IFUs)
+<https://jwst-docs.stsci.edu/display/JPP/Introduction+to+IFU+Spectroscopy>`__.
+It is built as part of the `glue visualiztion tool <http://glueviz.org>`__.
+CubeViz is designed to work with data cubes from the `NIRSpec
+<https://jwst-docs.stsci.edu/display/JTI/NIRSpec+IFU+Spectroscopy>`__ and `MIRI
+<https://jwst-docs.stsci.edu/display/JTI/MIRI+Medium-Resolution+Spectroscopy>`__
+instruments on `JWST
+<https://jwst-docs.stsci.edu/display/HOM/JWST+User+Documentation+Home>`__, and
+will work with data cubes from any IFU.  It uses the `specutils
+<https://specutils.readthedocs.io/en/latest/>`__ package from `Astropy
+<http://www.astropy.org>`__.
 
 The core functionality of CubeViz currently includes the ability to:
   * view the wavelength slices (RA, DEC) in a data cube,
@@ -16,7 +27,7 @@ Future functionality will include the ability to:
   * create moment maps,
   * create kinematic maps (rotation velocity and velocity dispersion),
   * create RGB images from regions collapsed in wavelength space (i.e., linemaps),
-  * perform continuum subtraction,  
+  * perform continuum subtraction,
   * overlay spectral line lists,
   * save edited cubes,
   * create publication quality figures,

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ conda_deps=
     astrodev,numpydev: cython
 conda_channels=
     gluedev: glueviz/label/dev
-passenv= SETUP_XVFB
+passenv= DISPLAY
 commands=
     pytest {posargs}
 
@@ -79,4 +79,4 @@ commands=
                  -m pytest --remote-data
     coverage report -m
     coveralls --rcfile={toxinidir}/cubeviz/tests/coveragerc
-passenv= TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH SETUP_XVFB
+passenv= TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DISPLAY

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,82 @@
+[testenv]
+deps=
+    pytest
+    pytest-qt
+    pytest-sugar
+    pytest-astropy
+    pytest-faulthandler
+    astrodev: git+git://github.com/astropy/astropy
+    numpydev: git+git://github.com/numpy/numpy
+# These are the minimum dependencies required in order to set up our conda
+# environment to enable the PyQt GUI
+conda_deps=
+    pyqt
+    matplotlib
+    gluedev: glue-core
+    astrodev,numpydev: cython
+conda_channels=
+    gluedev: glueviz/label/dev
+passenv= SETUP_XVFB
+commands=
+    pytest {posargs}
+
+[testenv:egg_info]
+deps=
+conda_deps=
+commands=
+    python setup.py egg_info
+
+[testenv:twine]
+basepython= python3.6
+deps=
+    twine
+conda_deps=
+commands=
+    twine check {distdir}/*
+
+[testenv:docbuild]
+basepython= python3.6
+deps=
+    sphinx-astropy
+    sphinx_rtd_theme
+conda_deps=
+    sphinx
+    graphviz
+    matplotlib
+commands=
+    python setup.py build_docs -w
+
+[testenv:checkdocs]
+basepython= python3.6
+deps=
+    collective.checkdocs
+    pygments
+commands=
+    python setup.py checkdocs
+
+[testenv:style]
+basepython= python3.6
+conda_deps=
+    flake8
+commands=
+    flake8 cubeviz --count
+
+[testenv:coverage]
+basepython= python3.6
+deps=
+    pytest
+    pytest-qt
+    pytest-sugar
+    pytest-astropy
+    pytest-faulthandler
+conda_deps=
+    pyqt
+    matplotlib
+    coverage
+    coveralls
+commands=
+    coverage run --source=cubeviz --rcfile={toxinidir}/cubeviz/tests/coveragerc \
+                 -m pytest --remote-data
+    coverage report -m
+    coveralls --rcfile={toxinidir}/cubeviz/tests/coveragerc
+passenv= TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH SETUP_XVFB


### PR DESCRIPTION
This greatly simplifies the CI config files and also allows test environments to be reproduced locally with minimal effort.