### PR TITLE
Removed sys.exit() wrapper

### DIFF
--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -118,4 +118,4 @@ def main(argv=sys.argv):
         ga.add_datasets(data_collection, datasets, auto_merge=False)
 
 
-    sys.exit(ga.start(maximized=True))
+    ga.start(maximized=True)


### PR DESCRIPTION
Per Tom, the sys.exit() wrapper should not have been there. Removed now and it closes fine without a popup and traceback.

Fixes #472 