### PR TITLE
WIP: Update dependency requirements and min python version

### DIFF
--- a/cubeviz/__init__.py
+++ b/cubeviz/__init__.py
@@ -4,6 +4,8 @@
 This is an Astropy affiliated package.
 """
 
+__minimum_python_version__ = "3.6"
+
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR updates the minimum versions etc for the dependencies and also sets the minimum Python version to 3.6. 

See discussion and notes in #470 (based on a discussion with @drdavella).

Fixes #470 