### PR TITLE
Added test against the oldest supported version of glue-core (0.13)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,9 @@ matrix:
         # Test against numpy dev
         - env: TOXENV='py36-numpydev'
 
+        # Test against oldest supported version of Glue
+        - env: TOXENV='py36-glueold'
+
         # Test against latest development version of Glue
         - env: TOXENV='py36-gluedev'
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,11 @@ deps=
 conda_deps=
     pyqt
     matplotlib
+    glueold: glue-core=0.13
     gluedev: glue-core
     astrodev,numpydev: cython
 conda_channels=
+    glueold: glueviz
     gluedev: glueviz/label/dev
 passenv= DISPLAY
 commands=


### PR DESCRIPTION
@drdavella - not sure if this is the best way to do it? Arguably we could also just have a ``legacy`` environment that tests against the oldest python and oldest version of every dependency? But maybe this is ok for now?