### PR TITLE
Switch from coveralls to codecov for coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CubeViz
 
 ![](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat)
-[![Coverage Status](https://coveralls.io/repos/github/spacetelescope/cubeviz/badge.svg?branch=master)](https://coveralls.io/github/spacetelescope/cubeviz?branch=master)
+[![Coverage Status](https://codecov.io/gh/spacetelescope/cubeviz/branch/master/graph/badge.svg)](https://codecov.io/gh/spacetelescope/cubeviz)
 
 For documentation see http://cubeviz.readthedocs.io/en/latest/
 
@@ -12,7 +12,7 @@ We are pleased to announce the release of CubeViz, a visualization and analysis 
 To install:
   * Install [Minconda3](https://conda.io/miniconda.html) if it is not on your system (**)
   * To install, type: `$ conda create -n cubeviz020 -c glueviz cubeviz`
-  
+
 To run:
   * Activate the environment: `$ source activate cubeviz020`
   * Run cubeviz: `$ cubeviz`

--- a/tox.ini
+++ b/tox.ini
@@ -78,5 +78,5 @@ commands=
     coverage run --source=cubeviz --rcfile={toxinidir}/cubeviz/tests/coveragerc \
                  -m pytest --remote-data
     coverage report -m
-    codecov
-passenv= TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DISPLAY
+    codecov -e TOXENV
+passenv= TOXENV CI TRAVIS TRAVIS_* CODECOV_* DISPLAY

--- a/tox.ini
+++ b/tox.ini
@@ -69,14 +69,14 @@ deps=
     pytest-sugar
     pytest-astropy
     pytest-faulthandler
+    codecov
 conda_deps=
     pyqt
     matplotlib
     coverage
-    coveralls
 commands=
     coverage run --source=cubeviz --rcfile={toxinidir}/cubeviz/tests/coveragerc \
                  -m pytest --remote-data
     coverage report -m
-    coveralls --rcfile={toxinidir}/cubeviz/tests/coveragerc
+    codecov
 passenv= TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DISPLAY


### PR DESCRIPTION
For astropy we've switched to codecov as it's easier to set up and has nice reporting options (including a comment in PRs, and information about the coverage of the code in the PR itself). I need to check it worked before we consider merging this though. PR comments will also only start appearing once this PR is merged.