### PR TITLE
Pin spectral cube version to avoid bug in 0.4.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/cubeviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.3.dev
-install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core>=0.13 specviz==0.5
+install_requires = numpy>=1.13 matplotlib astropy asdf pytest>=3.1 glue-core>=0.13 specviz==0.5 spectral_cube<0.4.4
 
 [entry_points]
 


### PR DESCRIPTION
This will hopefully serve as a workaround for the errors that have been happening on our nightly cron builds.