### PR TITLE
Version import fixes

### DIFF
--- a/cubeviz/conftest.py
+++ b/cubeviz/conftest.py
@@ -50,7 +50,7 @@ import os
 # This is to figure out the package version, rather than
 # using Astropy's
 try:
-    from .version import version
+    from . import __version__ as version
 except ImportError:
     version = 'dev'
 

--- a/cubeviz/cubeviz.py
+++ b/cubeviz/cubeviz.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     from glue.utils.decorators import die_on_error
 
-from .version import version as cubeviz_version
+from . import __version__ as cubeviz_version
 from .data_factories import DataFactoryConfiguration
 
 CUBEVIZ_ICON_PATH = os.path.abspath(

--- a/glue/_githash.py
+++ b/glue/_githash.py
@@ -1,2 +1,0 @@
-__githash__ = "d2c1a99"
-__dev_value__ = "217"


### PR DESCRIPTION
The version import doesn't work anymore now that setuptools_scm is used. Also removed a glue file which appeared.