### PR TITLE
Update CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,12 @@ env:
 
     matrix:
         # Make sure that installation does not fail
-        - TOXENV='py36' TOX_CMD='tox --notest' TOX_ARGS=''
+        - TOXENV='py37' TOX_CMD='tox --notest' TOX_ARGS=''
         # Make sure README will display properly on pypi
         - TOXENV='checkdocs'
         # Run a test with stable dependencies
         - TOXENV='py36'
+        - TOXENV='py37'
 
 matrix:
 
@@ -57,33 +58,25 @@ matrix:
 
         # Try MacOS X and Windows
         - os: osx
-          env: TOXENV='py36'
+          env: TOXENV='py37'
 
         - os: windows
-          env: TOXENV='py36'
-
-        # Test against Py37 (expected to fail for now)
-        - env: TOXENV='py37'
+          env: TOXENV='py37'
 
         # Try building against Astropy dev
-        - env: TOXENV='py36-astrodev'
+        - env: TOXENV='py37-astrodev'
 
         # Test against numpy dev
-        - env: TOXENV='py36-numpydev'
+        - env: TOXENV='py37-numpydev'
 
         # Test against latest development version of Glue
-        - env: TOXENV='py36-gluedev'
+        - env: TOXENV='py37-gluedev'
 
     allow_failures:
         - env: TOXENV='style' TOX_ARGS=''
-        - env: TOXENV='py37'
-        - env: TOXENV='py36-astrodev'
-        - env: TOXENV='py36-numpydev'
-        - env: TOXENV='py36-gluedev'
-
-        # Moved this here temporarily #479
-        - os: windows
-          env: TOXENV='py36'
+        - env: TOXENV='py37-astrodev'
+        - env: TOXENV='py37-numpydev'
+        - env: TOXENV='py37-gluedev'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ matrix:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
+    - conda install openssl
     - pip install tox tox-conda
 
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands=
     python setup.py egg_info
 
 [testenv:twine]
-basepython= python3.6
+basepython= python3.7
 deps=
     twine
 conda_deps=
@@ -34,7 +34,7 @@ commands=
     twine check {distdir}/*
 
 [testenv:docbuild]
-basepython= python3.6
+basepython= python3.7
 deps=
     sphinx-astropy
     sphinx_rtd_theme
@@ -46,7 +46,7 @@ commands=
     sphinx-build -W docs build/docs
 
 [testenv:checkdocs]
-basepython= python3.6
+basepython= python3.7
 deps=
     collective.checkdocs
     pygments
@@ -54,14 +54,14 @@ commands=
     python setup.py checkdocs
 
 [testenv:style]
-basepython= python3.6
+basepython= python3.7
 conda_deps=
     flake8
 commands=
     flake8 cubeviz --count
 
 [testenv:coverage]
-basepython= python3.6
+basepython= python3.7
 deps=
     pytest
     pytest-qt


### PR DESCRIPTION
Now that we require the latest `specviz` release, we can once again support Py37. This PR updates most of our CI tests to run against Py37. It also removes allowed failures that are no longer relevant.