### PR TITLE
Add pip-wheel-metadata to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ sdist
 develop-eggs
 .installed.cfg
 distribute-*.tar.gz
+pip-wheel-metadata
 
 # Other
 .cache


### PR DESCRIPTION
This directory appears to be generated by newer versions of `pip` when running `pip install -e .`. It needs to be added to the `.gitignore` file in order to prevent it from being accidentally committed in the future.