### PR TITLE
Update specviz data viewer explicitly to avoid message order issues

### DIFF
--- a/cubeviz/controls/wavelengths.py
+++ b/cubeviz/controls/wavelengths.py
@@ -84,8 +84,9 @@ class WavelengthController:
         self._send_wavelength_unit_message(units)
         self._send_wavelength_message(self._wavelengths)
 
-        specviz = self._cv_layout.specviz._widget
-        specviz.update_units(spectral_axis_unit=units)
+        self._cv_layout.specviz._widget.update_slice_indicator_position(
+            self._wavelengths[self._cv_layout._active_cube._widget.slice_index])
+        self._cv_layout.specviz._widget.update_units(spectral_axis_unit=units)
 
     def update_redshift(self, redshift, label=''):
         # If the input redshift is the current value we have then we are not

--- a/cubeviz/layout.py
+++ b/cubeviz/layout.py
@@ -410,7 +410,9 @@ class CubeVizLayout(QtWidgets.QWidget):
         data viewer.
         """
         unit = message.flux_units
-        self.specviz._widget.hub.plot_widget.data_unit = unit.to_string()
+
+        if unit is not None:
+            self.specviz._widget.hub.plot_widget.data_unit = unit.to_string()
 
     def _toggle_all_coords_in_degrees(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps=
     pytest-faulthandler
     legacy: numpy==1.13
     legacy: astropy==3.1
-    legacy: specviz==0.6.4
+    legacy: specviz==0.7.0
     astrodev: git+git://github.com/astropy/astropy
     numpydev: git+git://github.com/numpy/numpy
 # These are the minimum dependencies required in order to set up our conda


### PR DESCRIPTION
The order of event calls in glue is sometimes inconsistent, resulting in issues when updating the vertical line slice indicator in specviz. This PR avoids this by calling changes directly. Requires spacetelescope/specviz#639.