### PR TITLE
Prune toolbar options in image viewer

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -172,9 +172,12 @@ class CubevizImageLayerArtist(ImageLayerArtist):
 
 class CubevizImageViewer(ImageViewer):
 
-    tools = ['select:rectangle', 'select:xrange', 'select:yrange',
+    tools = ['save', 'mpl:home', 'mpl:pan', 'mpl:zoom',
+             'select:rectangle', 'select:xrange', 'select:yrange',
              'select:circle', 'select:polygon', 'image:contrast_bias',
              'cubeviz:contour']
+    subtools = {'save': ['mpl:save']}
+    _inherit_tools = False
 
     _state_cls = CubevizImageViewerState
     _close_on_last_layer_removed = False

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -175,7 +175,7 @@ class CubevizImageViewer(ImageViewer):
     tools = ['save', 'mpl:home', 'mpl:pan', 'mpl:zoom',
              'select:rectangle', 'select:xrange', 'select:yrange',
              'select:circle', 'select:polygon', 'image:contrast_bias',
-             'cubeviz:contour']
+             'cubeviz:contour', 'slice']
     subtools = {'save': ['mpl:save']}
     _inherit_tools = False
 


### PR DESCRIPTION
Removes the superfluous 1D profile view from the image viewer toolbar. Kind of addresses #547, ~#551~ (we're keeping that option now).

![Screen Shot 2019-03-12 at 11 14 48 AM](https://user-images.githubusercontent.com/4141126/54211653-121be500-44b8-11e9-86b5-73a38504ac11.png)
