### PR TITLE
Test image viewer unit display

### DIFF
--- a/cubeviz/controls/wavelengths.py
+++ b/cubeviz/controls/wavelengths.py
@@ -84,6 +84,9 @@ class WavelengthController:
         self._send_wavelength_unit_message(units)
         self._send_wavelength_message(self._wavelengths)
 
+        specviz = self._cv_layout.specviz._widget
+        specviz.update_units(spectral_axis_unit=units)
+
     def update_redshift(self, redshift, label=''):
         # If the input redshift is the current value we have then we are not
         # going to do anything.

--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -244,8 +244,6 @@ class CubevizImageViewer(ImageViewer):
         self._hub.subscribe(self, WavelengthUpdateMessage, handler=self._update_wavelengths)
         self._hub.subscribe(self, WavelengthUnitUpdateMessage, handler=self._update_wavelength_units)
         self._hub.subscribe(self, FluxUnitsUpdateMessage, handler=self._update_flux_units)
-        self._hub.subscribe(self, WavelengthUnitUpdateMessage,
-                            handler=lambda msg: self.cubeviz_layout.specviz._widget.update_units(spectral_axis_unit=msg.units))
 
     @property
     def cubeviz_unit(self):

--- a/cubeviz/tests/test_image_viewer.py
+++ b/cubeviz/tests/test_image_viewer.py
@@ -134,7 +134,7 @@ def test_viewer_title(cubeviz_layout):
         combo.setCurrentIndex(current_idx)
 
 
-def test_viewer_title_units_change(cubeviz_layout):
+def test_viewer_flux_units_change(cubeviz_layout):
     """
     Test whether viewer titles update appropriately with flux unit changes
     """
@@ -149,12 +149,40 @@ def test_viewer_title_units_change(cubeviz_layout):
 
         check_viewer_title(cubeviz_layout, idx, 0)
 
+        # Check whether the flux units associated with this viewer is correct.
+        # This is reflected in the mouseover display of flux values
+        assert cubeviz_layout.cube_views[idx]._widget.cubeviz_unit.unit == 'mJy'
+
         # Reset the combo when we're done
         combo = cubeviz_layout.get_viewer_combo(idx)
         combo.setCurrentIndex(current_idx)
 
     # Restore original units
     specviz.hub.plot_widget.set_data_unit(current_units)
+
+
+def test_viewer_wavelength_units_change(cubeviz_layout):
+    """
+    Test whether image viewer wavelength units are updated appropriately
+
+    These units are used by the viewer to populate the viewer status bar during
+    mouseover.
+    """
+
+    current_units = str(cubeviz_layout._wavelength_controller.current_units)
+
+    for viewer in cubeviz_layout.cube_views:
+        assert viewer._widget._wavelength_units == current_units
+
+    specviz = cubeviz_layout.specviz._widget
+    specviz.hub.plot_widget.set_spectral_axis_unit('Angstrom')
+
+    for viewer in cubeviz_layout.cube_views:
+        assert viewer._widget._wavelength_units == 'Angstrom'
+
+    # Restore original wavelength units
+    specviz.hub.plot_widget.set_spectral_axis_unit(current_units)
+
 
 def test_default_contour(cubeviz_layout):
     """


### PR DESCRIPTION
This resolves #512.

It is admittedly a somewhat indirect way to test these values. However, it is impracticable to emulate mouseover events in automated testing, and so this serves as a good proxy for determining the units that will be displayed.