### PR TITLE
Bump specviz dependency to reflect v0.7.0 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     astropy>=3.1
     asdf
     glue-core>=0.14
-    specviz>=0.6.4
+    specviz>=0.7.0
     spectral-cube<0.4.4
 
 [options.entry_points]


### PR DESCRIPTION
According to @nmearl this change is required due to some changes in the message interface between `specviz` and `cubeviz`.