### PR TITLE
Remove astropy helper references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "astropy_helpers"]
-	url = https://github.com/astropy/astropy-helpers.git
-	path = astropy_helpers
-	branch = refs/heads/v3.1


### PR DESCRIPTION
Atropy helpers was mistakenly added back in https://github.com/spacetelescope/cubeviz/pull/553.  So, this is to re-remove it again.