### PR TITLE
Re-add point selection in image viewers

### DIFF
--- a/cubeviz/image_viewer.py
+++ b/cubeviz/image_viewer.py
@@ -174,8 +174,8 @@ class CubevizImageViewer(ImageViewer):
 
     tools = ['save', 'mpl:home', 'mpl:pan', 'mpl:zoom',
              'select:rectangle', 'select:xrange', 'select:yrange',
-             'select:circle', 'select:polygon', 'image:contrast_bias',
-             'cubeviz:contour', 'slice']
+             'select:circle', 'select:polygon', 'image:point_selection',
+             'image:contrast_bias', 'cubeviz:contour', 'slice']
     subtools = {'save': ['mpl:save']}
     _inherit_tools = False
 


### PR DESCRIPTION
The point selection option was lost in previous PRs, this adds it back.

<img width="68" alt="Screen Shot 2019-03-28 at 12 47 45 PM" src="https://user-images.githubusercontent.com/4141126/55176627-dc355c80-5157-11e9-94c3-403aec391ba5.png">
