### PR TITLE
Update to reflect new release of tox-conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
     - conda install openssl
-    - pip install "tox~=3.7.0" tox-conda
+    - pip install tox tox-conda>=0.2
 
 script:
     - conda info


### PR DESCRIPTION
This is a follow-on to #581. Now that a new version of `tox-conda` has been released, we can remove the restriction on the `tox` version.