### PR TITLE
Pin dependency versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,13 @@ python_requires = >=3.6
 include_package_data = True
 setup_requires = setuptools_scm
 install_requires =
-    pyqt5<5.12
+    pyqt5>5.12
     numpy>=1.13
     matplotlib
-    astropy>=3.1
+    astropy<4.0
     asdf
-    glue-core>=0.14
-    specviz>=0.7.0
+    glue-core<0.15
+    specviz>=0.7
     spectral-cube<0.4.4
 
 [options.entry_points]


### PR DESCRIPTION
This PR pins the dependency versions to those tested. We have not update compatibility with the latest astropy and glue.

Addresses issue #591, along with spacetelescope/specviz#701.