### PR TITLE
Add Deprecation Warning to Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For documentation see http://cubeviz.readthedocs.io/en/latest/
 Current Status
 --------------
 
-Please note that this version of MOSViz is no longer being actively supported
-or maintained. The functionality of MOSViz is now available and being actively
-developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`.
+Please note that this version of CubeViz is no longer being actively supported
+or maintained. The functionality of CubeViz is now available and being actively
+developed as part of [Jdaviz](https://github.com/spacetelescope/jdaviz).
 
 ## Release 0.3
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ For documentation see http://cubeviz.readthedocs.io/en/latest/
 Current Status
 --------------
 
-Please note that this version of CubeViz is no longer being actively supported
-or maintained. The functionality of CubeViz is now available and being actively
+Please note that this version of CubeViz is **no longer being actively supported
+or maintained**. The functionality of CubeViz is now available and being actively
 developed as part of [Jdaviz](https://github.com/spacetelescope/jdaviz).
 
 ## Release 0.3

--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 Analysis Tasks
 ==============
 

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -1,5 +1,11 @@
 .. _developer_guide:
 
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 Developer Guide
 ===============
 

--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 Overview of Basic CubeViz Functionality
 =======================================
 

--- a/docs/image_viewers.rst
+++ b/docs/image_viewers.rst
@@ -1,3 +1,8 @@
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
 
 The Image Viewers
 =================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,12 @@
 CubeViz: Visualization & Analysis Tool for Data Cubes from Integral Field Units (IFUs)
 ======================================================================================
 
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 CubeViz is an visualization and analysis toolbox for data cubes from `integral
 field units (IFUs)
 <https://jwst-docs.stsci.edu/display/JPP/Introduction+to+IFU+Spectroscopy>`__.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 Installation
 ============
 

--- a/docs/readingindata.rst
+++ b/docs/readingindata.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 Loading Data
 ============
 

--- a/docs/shortcuts.rst
+++ b/docs/shortcuts.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 Keyboard Shortcuts
 ------------------
 

--- a/docs/spectrum_viewer.rst
+++ b/docs/spectrum_viewer.rst
@@ -1,3 +1,9 @@
+.. DANGER:: 
+
+      Please note that this version of CubeViz is **no longer being actively supported
+      or maintained**. The functionality of CubeViz is now available and being actively
+      developed as part of `Jdaviz <https://github.com/spacetelescope/jdaviz>`_.
+
 The Spectrum Viewer
 ===================
 


### PR DESCRIPTION
Adds a Danger Directive at the top of all docs pages warning the user that this isn't maintained anymore, directing them to jdaviz