### PR TITLE
Builds "last working release" for Qt-based CubeViz

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ github_project = spacetelescope/cubeviz
 [options]
 packages = find:
 zip_safe = False
-python_requires = ==3.6
+python_requires = ==3.6.13
 include_package_data = True
 setup_requires = setuptools_scm
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,17 +13,17 @@ github_project = spacetelescope/cubeviz
 [options]
 packages = find:
 zip_safe = False
-python_requires = >=3.6
+python_requires = ==3.6
 include_package_data = True
 setup_requires = setuptools_scm
 install_requires =
     pyqt5<5.12
     numpy>=1.13
     matplotlib
-    astropy>=3.1
+    astropy==3.1
     asdf
-    glue-core>=0.14
-    specviz>=0.7.0
+    glue-core==0.14
+    specviz==0.7.0
     spectral-cube<0.4.4
 
 [options.entry_points]


### PR DESCRIPTION
This PR fixes the old Qt-based CubeViz desktop app to the point it pops up the UI after a local installation from sources in a clean environment.

This doesn't mean the app works. Besides, in order to get it to render the UI at startup, the python version had to be pinned at 3.6.13, so all tests with other python versions are expected to fail. 

Should we care about CI errors for this "last release"?
